### PR TITLE
[Issue #4] Add __main__.py such that users can do python -m pdoc

### DIFF
--- a/pdoc/__main__.py
+++ b/pdoc/__main__.py
@@ -1,0 +1,6 @@
+#!/usr/bin/env python3
+
+from pdoc import cli
+
+if __name__ == "__main__":
+    cli.main(cli.parser.parse_args())

--- a/pdoc/__main__.py
+++ b/pdoc/__main__.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-from pdoc import cli
+from pdoc.cli import main
 
 if __name__ == "__main__":
-    cli.main(cli.parser.parse_args())
+    main()


### PR DESCRIPTION
Fixes https://github.com/pdoc3/pdoc/issues/4.

With this changes, users can do:

```
$ python3 -m pdoc
usage: __main__.py [-h] [--version] [--filter STRING] [--html]
                   [--html-dir DIR] [--html-no-source] [--overwrite]
                   [--external-links] [--template-dir DIR]
                   [--link-prefix STRING] [--http HOST:PORT]
                   MODULE [MODULE ...]
```

Thus even if the setuptools failed to generate the executable console binary (which happened to me on Mac and Linux), the users are still able to use the tool, without having to clone and touch the code.