### PR TITLE
Make source code button less dominant

### DIFF
--- a/pdoc/templates/css.mako
+++ b/pdoc/templates/css.mako
@@ -196,26 +196,20 @@
     }
 
     .source summary {
-      background: #ffc;
+      color: #666;
+      text-align: right;
       font-weight: 400;
       font-size: .8em;
-      width: 11em;
       text-transform: uppercase;
-      padding: 0px 8px;
-      border: 1px solid #fd6;
-      border-radius: 5px;
       cursor: pointer;
     }
-      .source summary:hover {
-        background: #fe9 !important;
-      }
-      .source[open] summary {
-        background: #fda;
-      }
     .source pre {
       max-height: 500px;
       overflow-y: scroll;
-      margin-bottom: 15px;
+      border: 0;
+      border-top: 1px solid #ddd;
+      border-bottom: 1px solid #ddd;
+      margin: 0;
     }
   .hlist {
     list-style: none;

--- a/pdoc/templates/css.mako
+++ b/pdoc/templates/css.mako
@@ -92,8 +92,11 @@
 
   pre {
     background: #f8f8f8;
-    border: 1px solid #ddd;
-    margin: 1em 0 1em 4ch;
+    border: 0;
+    border-top: 1px solid #ccc;
+    border-bottom: 1px solid #ccc;
+    margin: 1em 0;
+    padding: 1ex;
   }
 
   #http-server-module-list {
@@ -206,9 +209,6 @@
     .source pre {
       max-height: 500px;
       overflow-y: scroll;
-      border: 0;
-      border-top: 1px solid #ddd;
-      border-bottom: 1px solid #ddd;
       margin: 0;
     }
   .hlist {

--- a/pdoc/templates/css.mako
+++ b/pdoc/templates/css.mako
@@ -208,8 +208,11 @@
     }
     .source pre {
       max-height: 500px;
-      overflow-y: scroll;
+      overflow: auto;
       margin: 0;
+    }
+    .source pre code {
+      overflow: visible;
     }
   .hlist {
     list-style: none;

--- a/pdoc/templates/html.mako
+++ b/pdoc/templates/html.mako
@@ -37,7 +37,7 @@
     % if show_source_code and d.source and d.obj is not getattr(d.inherits, 'obj', None):
         <details class="source">
             <summary>Source code</summary>
-            <pre><code class="python">${d.source | h}}</code></pre>
+            <pre><code class="python">${d.source | h}</code></pre>
         </details>
     %endif
 </%def>


### PR DESCRIPTION
Personally, I find a source code button presented this way very distracting without providing any meaningful benefit. Thus I tried to make it less prominent in the rendered HTML.
Additionally, I removed a superfluous bracket that was rendered into the code view.

Here are some screens how it would look with this PR:
![image](https://user-images.githubusercontent.com/23704/51738632-d6f05e80-208f-11e9-95b6-bd129e458888.png)
![image](https://user-images.githubusercontent.com/23704/51738658-ea9bc500-208f-11e9-974a-ebb388450fbf.png)
