### PR TITLE
BUG: Html: Clicking on a Class in TOC no longer leads to superclass

### DIFF
--- a/pdoc/__init__.py
+++ b/pdoc/__init__.py
@@ -1274,11 +1274,6 @@ class Class(Doc):
         if not hasattr(self, '_super_members'):
             return
 
-        # Set inheritence for the Class itself
-        parent_cls = next(iter(self.mro(only_documented=True)), None)
-        if parent_cls and self.docstring == parent_cls.docstring:
-            self.inherits = parent_cls
-
         for name, parent_dobj in self._super_members.items():
             dobj = self.doc[name]
             if (dobj.obj is parent_dobj.obj or

--- a/pdoc/templates/html.mako
+++ b/pdoc/templates/html.mako
@@ -8,8 +8,7 @@
     if not isinstance(d, pdoc.Doc) or isinstance(d, pdoc.External) and not external_links:
         return name
     url = d.url(relative_to=module, link_prefix=link_prefix,
-                top_ancestor=(not show_inherited_members and
-                              not isinstance(self, pdoc.Class)))  # Because Classes are linked to
+                top_ancestor=not show_inherited_members)
     return '<a title="{}" href="{}">{}</a>'.format(d.refname, url, name)
 
 

--- a/pdoc/templates/html.mako
+++ b/pdoc/templates/html.mako
@@ -8,7 +8,8 @@
     if not isinstance(d, pdoc.Doc) or isinstance(d, pdoc.External) and not external_links:
         return name
     url = d.url(relative_to=module, link_prefix=link_prefix,
-                top_ancestor=not show_inherited_members)
+                top_ancestor=(not show_inherited_members and
+                              not isinstance(self, pdoc.Class)))  # Because Classes are linked to
     return '<a title="{}" href="{}">{}</a>'.format(d.refname, url, name)
 
 

--- a/pdoc/test/__init__.py
+++ b/pdoc/test/__init__.py
@@ -479,9 +479,11 @@ class ApiTest(unittest.TestCase):
         a = mod.doc['a'].doc['A']
         b = mod.doc['b'].doc['B']
         c = mod.doc['b'].doc['c'].doc['C']
-        self.assertEqual(b.inherits, a)
         self.assertEqual(b.doc['a'].inherits, a.doc['a'])
         self.assertEqual(b.doc['c'].inherits, c.doc['c'])
+        # While classes do inherit from superclasses, they just shouldn't always
+        # say so, because public classes do want to be exposed and linked to
+        self.assertNotEqual(b.inherits, a)
 
     def test_context(self):
         context = {}
@@ -521,7 +523,7 @@ class ApiTest(unittest.TestCase):
         self.assertEqual(c.url(), 'example_pkg/index.html#example_pkg.D')
         self.assertEqual(c.url(link_prefix='/'), '/example_pkg/index.html#example_pkg.D')
         self.assertEqual(c.url(relative_to=c.module), '#example_pkg.D')
-        self.assertEqual(c.url(top_ancestor=True), 'example_pkg/index.html#example_pkg.B')
+        self.assertEqual(c.url(top_ancestor=True), c.url())  # Public classes do link to themselves
 
         f = c.doc['overridden']
         self.assertEqual(f.url(), 'example_pkg/index.html#example_pkg.D.overridden')


### PR DESCRIPTION
Fixes https://github.com/pdoc3/pdoc/issues/17.