### PR TITLE
ENH: optional sorting of variables, classes, functions

### DIFF
--- a/pdoc/templates/config.mako
+++ b/pdoc/templates/config.mako
@@ -4,4 +4,5 @@
     show_inherited_members = False
     extract_module_toc_into_sidebar = True
     list_class_variables_in_index = True
+    sort_identifiers = True
 %>

--- a/pdoc/templates/html.mako
+++ b/pdoc/templates/html.mako
@@ -24,6 +24,7 @@
     show_inherited_members = getattr(config.attr, 'show_inherited_members', True)
     extract_module_toc_into_sidebar = getattr(config.attr, 'extract_module_toc_into_sidebar', True)
     list_class_variables_in_index = getattr(config.attr, 'list_class_variables_in_index', False)
+    sort_identifiers = getattr(config.attr, 'sort_identifiers', True)
 
     link = getattr(config.attr, 'link', link)
     to_html = getattr(config.attr, 'to_html', to_html)
@@ -93,9 +94,9 @@
 
 <%def name="show_module(module)">
   <%
-  variables = module.variables()
-  classes = module.classes()
-  functions = module.functions()
+  variables = module.variables(sort=sort_identifiers)
+  classes = module.classes(sort=sort_identifiers)
+  functions = module.functions(sort=sort_identifiers)
   submodules = module.submodules()
   %>
 
@@ -166,10 +167,10 @@
     <dl>
     % for c in classes:
       <%
-      class_vars = c.class_variables(show_inherited_members)
-      smethods = c.functions(show_inherited_members)
-      inst_vars = c.instance_variables(show_inherited_members)
-      methods = c.methods(show_inherited_members)
+      class_vars = c.class_variables(show_inherited_members, sort=sort_identifiers)
+      smethods = c.functions(show_inherited_members, sort=sort_identifiers)
+      inst_vars = c.instance_variables(show_inherited_members, sort=sort_identifiers)
+      methods = c.methods(show_inherited_members, sort=sort_identifiers)
       mro = c.mro()
       subclasses = c.subclasses()
       %>
@@ -255,9 +256,9 @@
 
 <%def name="module_index(module)">
   <%
-  variables = module.variables()
-  classes = module.classes()
-  functions = module.functions()
+  variables = module.variables(sort=sort_identifiers)
+  classes = module.classes(sort=sort_identifiers)
+  functions = module.functions(sort=sort_identifiers)
   submodules = module.submodules()
   supermodule = module.supermodule
   %>
@@ -305,12 +306,14 @@
         <li>
         <h4><code>${link(c)}</code></h4>
         <%
-            members = c.functions() + c.methods()
+            members = c.functions(sort=sort_identifiers) + c.methods(sort=sort_identifiers)
             if list_class_variables_in_index:
-                members += c.instance_variables() + c.class_variables()
+                members += (c.instance_variables(sort=sort_identifiers) +
+                            c.class_variables(sort=sort_identifiers))
             if not show_inherited_members:
                 members = [i for i in members if not i.inherits]
-            members = sorted(members)
+            if sort_identifiers:
+              members = sorted(members)
         %>
         % if members:
           ${show_column_list(members)}

--- a/pdoc/test/__init__.py
+++ b/pdoc/test/__init__.py
@@ -537,6 +537,32 @@ class ApiTest(unittest.TestCase):
         self.assertEqual(f.url(relative_to=c.module), '#example_pkg.D.overridden')
         self.assertEqual(f.url(top_ancestor=1), 'example_pkg/index.html#example_pkg.B.overridden')
 
+    @unittest.skipIf(sys.version_info < (3, 6), reason="only deterministic on CPython 3.6+")
+    def test_sorting(self):
+        module = pdoc.Module(pdoc.import_module(EXAMPLE_MODULE))
+
+        sorted_variables = module.variables()
+        unsorted_variables = module.variables(sort=False)
+        self.assertNotEqual(sorted_variables, unsorted_variables)
+        self.assertEqual(sorted_variables, sorted(unsorted_variables))
+
+        sorted_functions = module.functions()
+        unsorted_functions = module.functions(sort=False)
+        self.assertNotEqual(sorted_functions, unsorted_functions)
+        self.assertEqual(sorted_functions, sorted(unsorted_functions))
+
+        sorted_classes = module.classes()
+        unsorted_classes = module.classes(sort=False)
+        self.assertNotEqual(sorted_classes, unsorted_classes)
+        self.assertEqual(sorted_classes, sorted(unsorted_classes))
+
+        cls = module.doc["Docformats"]
+
+        sorted_methods = cls.methods()
+        unsorted_methods = cls.methods(sort=False)
+        self.assertNotEqual(sorted_methods, unsorted_methods)
+        self.assertEqual(sorted_methods, sorted(unsorted_methods))
+
 
 class HtmlHelpersTest(unittest.TestCase):
     """


### PR DESCRIPTION
Closes #23 

I wasn't able to make module-sorting optional as it seems to happen while walking the file tree, and I didn't really know what to do about `inherited_members` so I left them alone :)