### PR TITLE
ENH: Configurable highlight style

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 dist
 build
+*.eggs/*
 *.egg-info
 *.py[cod]
 

--- a/pdoc/templates/config.mako
+++ b/pdoc/templates/config.mako
@@ -5,7 +5,8 @@
     extract_module_toc_into_sidebar = True
     list_class_variables_in_index = True
     sort_identifiers = True
-    # Set the style keyword such as 'atom-one-light' or 'github-gist'. Default is 'github'
-    # Options: https://github.com/highlightjs/highlight.js/tree/master/src/styles
-    hljs_stylename = 'github'
+    # Set the style keyword such as 'atom-one-light' or 'github-gist'
+    #     Options: https://github.com/highlightjs/highlight.js/tree/master/src/styles
+    #     Demo: https://highlightjs.org/static/demo/
+    hljs_style = 'github'
 %>

--- a/pdoc/templates/config.mako
+++ b/pdoc/templates/config.mako
@@ -5,4 +5,7 @@
     extract_module_toc_into_sidebar = True
     list_class_variables_in_index = True
     sort_identifiers = True
+    # Set the style keyword such as 'atom-one-light' or 'github-gist'. Default is 'github'
+    # Options: https://github.com/highlightjs/highlight.js/tree/master/src/styles
+    hljs_stylename = 'github'
 %>

--- a/pdoc/templates/css.mako
+++ b/pdoc/templates/css.mako
@@ -156,7 +156,6 @@
     }
     dd p {
       margin: 10px 0;
-      white-space: pre-wrap;
     }
     .name {
       background: #eee;
@@ -201,20 +200,14 @@
     }
 
     .source summary {
-      background-color: #fafafa; /* Match HLJS backgd */
       color: #666;
       text-align: right;
       font-weight: 400;
       font-size: .8em;
-      padding: 1px 5px;
       text-transform: uppercase;
       cursor: pointer;
     }
-      .source summary:focus {
-        outline: none !important;
-      }
     .source pre {
-      background-color: #fafafa; /* Match HLJS backgd */
       max-height: 500px;
       overflow: auto;
       margin: 0;
@@ -222,7 +215,6 @@
     .source pre code {
       font-size: 12px;
       overflow: visible;
-      padding-bottom: 1em;
     }
   .hlist {
     list-style: none;
@@ -272,104 +264,6 @@
     .admonition.caution {
       background: lightpink;
     }
-
-/*
-
-Atom One Light by Daniel Gamage
-Original One Light Syntax theme from https://github.com/atom/one-light-syntax
-
-base:    #fafafa
-mono-1:  #383a42
-mono-2:  #686b77
-mono-3:  #a0a1a7
-hue-1:   #0184bb
-hue-2:   #4078f2
-hue-3:   #a626a4
-hue-4:   #50a14f
-hue-5:   #e45649
-hue-5-2: #c91243
-hue-6:   #986801
-hue-6-2: #c18401
-
-*/
-
-.hljs {
-  display: block;
-  overflow-x: auto;
-  padding: 0.5em;
-  color: #383a42;
-  background: #fafafa;
-}
-
-.hljs-comment,
-.hljs-quote {
-  color: #a0a1a7;
-  font-style: italic;
-}
-
-.hljs-doctag,
-.hljs-keyword,
-.hljs-formula {
-  color: #a626a4;
-}
-
-.hljs-section,
-.hljs-name,
-.hljs-selector-tag,
-.hljs-deletion,
-.hljs-subst {
-  color: #e45649;
-}
-
-.hljs-literal {
-  color: #0184bb;
-}
-
-.hljs-string,
-.hljs-regexp,
-.hljs-addition,
-.hljs-attribute,
-.hljs-meta-string {
-  color: #50a14f;
-}
-
-.hljs-built_in,
-.hljs-class .hljs-title {
-  color: #c18401;
-}
-
-.hljs-attr,
-.hljs-variable,
-.hljs-template-variable,
-.hljs-type,
-.hljs-selector-class,
-.hljs-selector-attr,
-.hljs-selector-pseudo,
-.hljs-number {
-  color: #986801;
-}
-
-.hljs-symbol,
-.hljs-bullet,
-.hljs-link,
-.hljs-meta,
-.hljs-selector-id,
-.hljs-title {
-  color: #4078f2;
-}
-
-.hljs-emphasis {
-  font-style: italic;
-}
-
-.hljs-strong {
-  font-weight: bold;
-}
-
-.hljs-link {
-  text-decoration: underline;
-}
-
 </%def>
 
 <%def name="desktop()" filter="minify_css">

--- a/pdoc/templates/css.mako
+++ b/pdoc/templates/css.mako
@@ -156,6 +156,7 @@
     }
     dd p {
       margin: 10px 0;
+      white-space: pre-wrap;
     }
     .name {
       background: #eee;
@@ -200,20 +201,28 @@
     }
 
     .source summary {
+      background-color: #fafafa; /* Match HLJS backgd */
       color: #666;
       text-align: right;
       font-weight: 400;
       font-size: .8em;
+      padding: 1px 5px;
       text-transform: uppercase;
       cursor: pointer;
     }
+      .source summary:focus {
+        outline: none !important;
+      }
     .source pre {
+      background-color: #fafafa; /* Match HLJS backgd */
       max-height: 500px;
       overflow: auto;
       margin: 0;
     }
     .source pre code {
+      font-size: 12px;
       overflow: visible;
+      padding-bottom: 1em;
     }
   .hlist {
     list-style: none;
@@ -263,6 +272,104 @@
     .admonition.caution {
       background: lightpink;
     }
+
+/*
+
+Atom One Light by Daniel Gamage
+Original One Light Syntax theme from https://github.com/atom/one-light-syntax
+
+base:    #fafafa
+mono-1:  #383a42
+mono-2:  #686b77
+mono-3:  #a0a1a7
+hue-1:   #0184bb
+hue-2:   #4078f2
+hue-3:   #a626a4
+hue-4:   #50a14f
+hue-5:   #e45649
+hue-5-2: #c91243
+hue-6:   #986801
+hue-6-2: #c18401
+
+*/
+
+.hljs {
+  display: block;
+  overflow-x: auto;
+  padding: 0.5em;
+  color: #383a42;
+  background: #fafafa;
+}
+
+.hljs-comment,
+.hljs-quote {
+  color: #a0a1a7;
+  font-style: italic;
+}
+
+.hljs-doctag,
+.hljs-keyword,
+.hljs-formula {
+  color: #a626a4;
+}
+
+.hljs-section,
+.hljs-name,
+.hljs-selector-tag,
+.hljs-deletion,
+.hljs-subst {
+  color: #e45649;
+}
+
+.hljs-literal {
+  color: #0184bb;
+}
+
+.hljs-string,
+.hljs-regexp,
+.hljs-addition,
+.hljs-attribute,
+.hljs-meta-string {
+  color: #50a14f;
+}
+
+.hljs-built_in,
+.hljs-class .hljs-title {
+  color: #c18401;
+}
+
+.hljs-attr,
+.hljs-variable,
+.hljs-template-variable,
+.hljs-type,
+.hljs-selector-class,
+.hljs-selector-attr,
+.hljs-selector-pseudo,
+.hljs-number {
+  color: #986801;
+}
+
+.hljs-symbol,
+.hljs-bullet,
+.hljs-link,
+.hljs-meta,
+.hljs-selector-id,
+.hljs-title {
+  color: #4078f2;
+}
+
+.hljs-emphasis {
+  font-style: italic;
+}
+
+.hljs-strong {
+  font-weight: bold;
+}
+
+.hljs-link {
+  text-decoration: underline;
+}
+
 </%def>
 
 <%def name="desktop()" filter="minify_css">

--- a/pdoc/templates/html.mako
+++ b/pdoc/templates/html.mako
@@ -25,6 +25,7 @@
     extract_module_toc_into_sidebar = getattr(config.attr, 'extract_module_toc_into_sidebar', True)
     list_class_variables_in_index = getattr(config.attr, 'list_class_variables_in_index', False)
     sort_identifiers = getattr(config.attr, 'sort_identifiers', True)
+    hljs_stylename = getattr(config.attr, 'hljs_stylename', 'github')
 
     link = getattr(config.attr, 'link', link)
     to_html = getattr(config.attr, 'to_html', to_html)
@@ -350,7 +351,7 @@
   <link href='https://cdnjs.cloudflare.com/ajax/libs/normalize/8.0.0/normalize.min.css' rel='stylesheet'>
   <link href='https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/8.0.0/sanitize.min.css' rel='stylesheet'>
   % if show_source_code:
-    <link href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/styles/github.min.css" rel="stylesheet">
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/styles/${hljs_stylename}.min.css" rel="stylesheet">
   %endif
 
   <%namespace name="css" file="css.mako" />

--- a/pdoc/templates/html.mako
+++ b/pdoc/templates/html.mako
@@ -25,7 +25,7 @@
     extract_module_toc_into_sidebar = getattr(config.attr, 'extract_module_toc_into_sidebar', True)
     list_class_variables_in_index = getattr(config.attr, 'list_class_variables_in_index', False)
     sort_identifiers = getattr(config.attr, 'sort_identifiers', True)
-    hljs_stylename = getattr(config.attr, 'hljs_stylename', 'github')
+    hljs_style = getattr(config.attr, 'hljs_style', 'github')
 
     link = getattr(config.attr, 'link', link)
     to_html = getattr(config.attr, 'to_html', to_html)
@@ -351,7 +351,7 @@
   <link href='https://cdnjs.cloudflare.com/ajax/libs/normalize/8.0.0/normalize.min.css' rel='stylesheet'>
   <link href='https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/8.0.0/sanitize.min.css' rel='stylesheet'>
   % if show_source_code:
-    <link href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/styles/${hljs_stylename}.min.css" rel="stylesheet">
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/styles/${hljs_style}.min.css" rel="stylesheet">
   %endif
 
   <%namespace name="css" file="css.mako" />


### PR DESCRIPTION
Fixes #34 

-----

I'd be happy to undo *any* (hopefully not all 😄 ) of these changes, so let me know if you want to implement 1, 3, and 5 but not 2 and 4, etc. The four main changes are listed below and shown in side-by-side screenshot comparisons below:

1. Implement `Atom One Light` Highlight.js style (other alternatives could be `Foundation`, `Github Gist`, `A 11 Y Light`, or others from https://highlightjs.org/static/demo/). This directly addresses #34
1. Preserve newlines from source code docstrings with `white-space: pre-wrap;`. At work, we have a compact docstring style where the newlines need to be preserved in the documentation. See discussion from pdoc: [pdoc/179#comment](https://github.com/mitmproxy/pdoc/issues/179#issuecomment-466465655). I think keeping the newlines is more consistent with how the comments were written in a text editor, but I'm open to dropping this change
1. Highlight the entire click region for `SOURCE CODE` with the same background color as the hljs style (and add a small amount of padding) (`background-color: #fafafa; /* Match HLJS backgd */`)
1. Shrink the code text to 12px so it fits more compactly for easier review
1. Remove the blue selection box when clicking the `SOURCE CODE` element (`outline: none !important;`)

# Screenshots

Each example shows all of the proposed changes, but I call-out specific changes for each example. Generated with:

1. `pip install beautifulsoup4`
1.  `pdoc bs4 --http localhost:8000`

## Example 1

### Proposed

<img width="920" alt="screen shot 2019-02-24 at 05 53 04" src="https://user-images.githubusercontent.com/3784339/53298496-f4cef180-37fc-11e9-9255-73cd8c8db0d0.png">

### Current

<img width="909" alt="screen shot 2019-02-24 at 05 55 30" src="https://user-images.githubusercontent.com/3784339/53298497-f698b500-37fc-11e9-97e3-6f3687312e54.png">

### Notes

2 - Examples 1 and 2 show how the `pre-wrap` change comes into play causing the newlines from the source code to be preserved

5 -  Because of `cursor: pointer;`, when you click `SOURCE CODE`, the browser will momentary highlight the div. In the proposed version, `outline: none !important;` prevents the blue highlight from appearing on click (`focus`)

## Example 2

### Proposed

<img width="858" alt="screen shot 2019-02-24 at 06 28 58" src="https://user-images.githubusercontent.com/3784339/53298555-bdad1000-37fd-11e9-9cf5-2ff790f7868a.png">

### Current

<img width="845" alt="screen shot 2019-02-24 at 06 30 11" src="https://user-images.githubusercontent.com/3784339/53298556-c69de180-37fd-11e9-9f4c-6a5c4a5ffbbb.png">

### Notes

2 - See how the `pre-wrap` change comes into play causing the newlines from the source code to be preserved (`decode()` and `handle_starttag()`)

3 - The clickable region for source code is lightly highlighted

## Example 3

### Proposed

<img width="849" alt="screen shot 2019-02-24 at 05 52 14" src="https://user-images.githubusercontent.com/3784339/53298499-f8fb0f00-37fc-11e9-914a-cf283d4393ad.png">

### Current

<img width="842" alt="screen shot 2019-02-24 at 05 58 26" src="https://user-images.githubusercontent.com/3784339/53298501-fb5d6900-37fc-11e9-8c39-febc62614e40.png">

### Notes

1,4 - The source code variable and built-ins are more clearly highlighted and the code better fits within the height-limited section