### PR TITLE
Fix favicon.ico error when using `--http`. Fixes #35

### DIFF
--- a/pdoc/cli.py
+++ b/pdoc/cli.py
@@ -198,7 +198,7 @@ class WebDoc(BaseHTTPRequestHandler):
         the source code.
         """
         # Deny favicon shortcut early.
-        if self.path == "/favicon.ico":
+        if self.import_path_from_req_url == "favicon.ico":
             return None
 
         # TODO: pass extra pdoc.html() params


### PR DESCRIPTION
Simple fix because `self.path` could be `/favicon.ico/` while `self.import_path_from_req_url` is more consistent to check against `favicon.ico`