### PR TITLE
Fix: Relative path for Sub-Modules on Windows

### DIFF
--- a/pdoc/__init__.py
+++ b/pdoc/__init__.py
@@ -833,8 +833,8 @@ class Doc:
 
         # Otherwise, compute relative path from current module to link target
         url = os.path.relpath(self._url(), relative_to.url())
-        # We have one set of '..' too many. Handle Windows and UNIX slashes
-        if re.match(r'^\.\.[\/\\]', url):
+        # We have one set of '..' too many
+        if url.startswith('..' + os.path.sep):
             url = url[3:]
         return url
 

--- a/pdoc/__init__.py
+++ b/pdoc/__init__.py
@@ -832,9 +832,9 @@ class Doc:
             return '#' + self.refname
 
         # Otherwise, compute relative path from current module to link target
-        url = os.path.relpath(self._url(), relative_to.url())
+        url = os.path.relpath(self._url(), relative_to.url()).replace(path.sep, '/')
         # We have one set of '..' too many
-        if url.startswith('..' + os.path.sep):
+        if url.startswith('../'):
             url = url[3:]
         return url
 

--- a/pdoc/__init__.py
+++ b/pdoc/__init__.py
@@ -833,8 +833,8 @@ class Doc:
 
         # Otherwise, compute relative path from current module to link target
         url = os.path.relpath(self._url(), relative_to.url())
-        # We have one set of '..' too many
-        if url.startswith('../'):
+        # We have one set of '..' too many. Handle Windows and UNIX slashes
+        if re.match(r'^\.\.[\/\\]', url):
             url = url[3:]
         return url
 


### PR DESCRIPTION
Fixes #41 

`startswith('../')` was only catching UNIX-like paths. Replaced with check for both UNIX and Windows paths
Could also be `if url.startswith('../') or url.startswith('..\\'):`