### PR TITLE
Allow for no call to subclasses for a metaclass

### DIFF
--- a/pdoc/__init__.py
+++ b/pdoc/__init__.py
@@ -1210,6 +1210,8 @@ class Class(Doc):
         The objects in the list are of type `pdoc.Class` if available,
         and `pdoc.External` otherwise.
         """
+        if type(self.obj) == type:
+            return []
         return [self.module.find_class(c)
                 for c in self.obj.__subclasses__()]
 


### PR DESCRIPTION
It looks like a check in pdoc was not migrated to pdoc3?  This is a check to make sure subclasses isn't called since the interface is different.