### PR TITLE
Change type annotation arrow character

### DIFF
--- a/pdoc/templates/html.mako
+++ b/pdoc/templates/html.mako
@@ -90,7 +90,7 @@
             params = ', '.join(f.params(annotate=show_type_annotations, link=link))
             returns = show_type_annotations and f.return_annotation(link=link) or ''
             if returns:
-                returns = ' \u2192\xA0' + returns
+                returns = ' ->\xA0' + returns
         %>
         <span>${f.funcdef()} ${ident(f.name)}</span>(<span>${params})${returns}</span>
     </code></dt>

--- a/pdoc/templates/html.mako
+++ b/pdoc/templates/html.mako
@@ -90,7 +90,7 @@
             params = ', '.join(f.params(annotate=show_type_annotations, link=link))
             returns = show_type_annotations and f.return_annotation(link=link) or ''
             if returns:
-                returns = ' 🡢\xA0' + returns
+                returns = ' \u2192\xA0' + returns
         %>
         <span>${f.funcdef()} ${ident(f.name)}</span>(<span>${params})${returns}</span>
     </code></dt>


### PR DESCRIPTION
The new type annotations HTML output use an arrow character that isn't widely supported, or at least it doesn't render for me in Chrome 73 on macOS Mojave.
Can we change to a more commonly supported character, ie: &rarr;

Change from the arrow character used to render the return type annotation from
WIDE-HEADED RIGHTWARDS LIGHT BARB ARROW (http://www.fileformat.info/info/unicode/char/1f862/index.htm)
to the more widely supported
RIGHTWARDS ARROW (https://www.fileformat.info/info/unicode/char/2192/index.htm)