### PR TITLE
live reload when serving locally #60

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,7 @@ if __name__ == '__main__':
         install_requires=[
             "mako",
             "markdown >= 3.0",
+            "livereload",
         ],
         setup_requires=[
             'setuptools_git',


### PR DESCRIPTION
This adds the live reload functionality.

> If something can be done in about three lines of WebSocket JS API and maybe twice that on the Python end without heavy extra dependencies, absolutely love to see it.

It takes zero lines of JS (!) and ended up with approximately the same lines of Python. It uses a single dependency, `livereload`.

Watches files for changes, then automatically regenerates html and reloads any webpages that are viewing the generated html. This works on pdoc as well now.

TODO
- [x] Get proof of concept working
- [ ] Honor other pdoc arguments (I didn't look into them in detail, because I didn't want to spend too much time on this before I got initial feedback from you)
- [ ] Call a pdoc function rather than shelling out to a subprocess
- [ ] Generate index.html to avoid needing to go to `host:port/module`
- [ ] Update unit tests