### PR TITLE
Fix generating Markdown when using outputdir

### DIFF
--- a/pdoc/cli.py
+++ b/pdoc/cli.py
@@ -316,7 +316,7 @@ def write_files(m: pdoc.Module, ext: str, **kwargs):
             if ext == '.html':
                 w.write(m.html(**kwargs))
             elif ext == '.md':
-                w.write(m.html(**kwargs))
+                w.write(m.text(**kwargs))
     except Exception:
         try:
             os.unlink(f)


### PR DESCRIPTION
The generation of textfiles / markdownfiles was not working when the parameter -o / --outputdir was omitted, instead, HTML-Files were generated.