### PR TITLE
ENH: Support LaTeX math syntax with MathJax

### DIFF
--- a/pdoc/documentation.md
+++ b/pdoc/documentation.md
@@ -177,12 +177,23 @@ Supported docstring formats
 ---------------------------
 Currently, pure Markdown (with [extensions]), [numpydoc],
 and [Google-style] docstrings formats are supported,
-along with some reST directives.
+along with some [reST directives].
+
+Additionally, if `latex_math` [template config] option is enabled,
+LaTeX math syntax is supported when placed between
+[recognized delimiters]: `\(...\)` for inline equations and
+`\[...\]` or `$$...$$` for block equations. Note, you need to escape
+your backslashes in Python docstrings (`\\(`, `\\frac{}{}`, ...)
+or, alternatively, use [raw string literals].
 
 *[reST]: reStructuredText
 [extensions]: https://python-markdown.github.io/extensions/#officially-supported-extensions
 [numpydoc]: https://numpydoc.readthedocs.io/
 [Google-style]: http://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings
+[reST directives]: #supported-rest-directives
+[template config]: #custom-templates
+[recognized delimiters]: http://docs.mathjax.org/en/latest/tex.html#tex-and-latex-math-delimiters
+[raw string literals]: https://www.journaldev.com/23598/python-raw-string
 
 
 ### Supported reST directives
@@ -193,6 +204,7 @@ The following reST directives should work:
 * [`.. image::`][image] or `.. figure::` (without options),
 * [`.. include::`][include], with support for the options:
   `:start-line:`, `:end-line:`, `:start-after:` and `:end-before:`.
+* [`.. math::`][math]
 * `.. versionadded::`
 * `.. versionchanged::`
 * `.. deprecated::`
@@ -201,6 +213,7 @@ The following reST directives should work:
 [admonitions]: http://docutils.sourceforge.net/docs/ref/rst/directives.html#admonitions
 [image]: http://docutils.sourceforge.net/docs/ref/rst/directives.html#images
 [include]: http://docutils.sourceforge.net/docs/ref/rst/directives.html#including-an-external-document-fragment
+[math]: http://docutils.sourceforge.net/docs/ref/rst/directives.html#math
 
 
 Linking to other identifiers

--- a/pdoc/templates/config.mako
+++ b/pdoc/templates/config.mako
@@ -24,4 +24,11 @@
     # If set, insert Google Analytics tracking code. Value is GA
     # tracking id (UA-XXXXXX-Y).
     google_analytics = ''
+
+    # If set, render LaTeX math syntax within \(...\) (inline equations),
+    # or within \[...\] or $$...$$ or `.. math::` (block equations)
+    # as nicely-formatted math formulas using MathJax.
+    # Note: in Python docstrings, either all backslashes need to be escaped (\\)
+    # or you need to use raw r-strings.
+    latex_math = False
 %>

--- a/pdoc/templates/html.mako
+++ b/pdoc/templates/html.mako
@@ -15,7 +15,7 @@
 
 
   def to_html(text):
-    return _to_html(text, module=module, link=link)
+    return _to_html(text, module=module, link=link, latex_math=latex_math)
 %>
 
 <%def name="ident(name)"><span class="ident">${name}</span></%def>
@@ -365,6 +365,10 @@
     window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
     ga('create', '${google_analytics}', 'auto'); ga('send', 'pageview');
     </script><script async src='https://www.google-analytics.com/analytics.js'></script>
+  % endif
+
+  % if latex_math:
+    <script async src='https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/latest.js?config=TeX-AMS_CHTML'></script>
   % endif
 
   <%include file="head.mako"/>

--- a/pdoc/test/__init__.py
+++ b/pdoc/test/__init__.py
@@ -1030,6 +1030,15 @@ data:text/plain;base64,SGVsbG8sIFdvcmxkIQ%3D%3D"""
         html = to_html(text)
         self.assertEqual(html, expected)
 
+    def test_latex_math(self):
+        expected = r'''<p>Inline equation: \( v_t *\frac{1}{2}* j_i + [a](#b) &lt; 3 \).</p>
+<p>Block equation: \[ v_t *\frac{1}{2}* j_i + [a](#b) &lt; 3 \]</p>
+<p>Block equation: $$ v_t *\frac{1}{2}* j_i + [a](#b) &lt; 3 $$</p>
+<p>\[ v_t *\frac{1}{2}* j_i + [a](#b) &lt; 3 \]</p>'''
+        text = inspect.getdoc(self._docmodule.latex_math)
+        html = to_html(text, module=self._module, link=self._link, latex_math=True)
+        self.assertEqual(html, expected)
+
 
 class HttpTest(unittest.TestCase):
     """

--- a/pdoc/test/__init__.py
+++ b/pdoc/test/__init__.py
@@ -1031,10 +1031,10 @@ data:text/plain;base64,SGVsbG8sIFdvcmxkIQ%3D%3D"""
         self.assertEqual(html, expected)
 
     def test_latex_math(self):
-        expected = r'''<p>Inline equation: \( v_t *\frac{1}{2}* j_i + [a](#b) &lt; 3 \).</p>
-<p>Block equation: \[ v_t *\frac{1}{2}* j_i + [a](#b) &lt; 3 \]</p>
-<p>Block equation: $$ v_t *\frac{1}{2}* j_i + [a](#b) &lt; 3 $$</p>
-<p>\[ v_t *\frac{1}{2}* j_i + [a](#b) &lt; 3 \]</p>'''
+        expected = r'''<p>Inline equation: <span><span class="MathJax_Preview"> v_t *\frac{1}{2}* j_i + [a] &lt; 3 </span><script type="math/tex"> v_t *\frac{1}{2}* j_i + [a] < 3 </script></span>.</p>
+<p>Block equation: <span><span class="MathJax_Preview"> v_t *\frac{1}{2}* j_i + [a] &lt; 3 </span><script type="math/tex; mode=display"> v_t *\frac{1}{2}* j_i + [a] < 3 </script></span></p>
+<p>Block equation: <span><span class="MathJax_Preview"> v_t *\frac{1}{2}* j_i + [a] &lt; 3 </span><script type="math/tex; mode=display"> v_t *\frac{1}{2}* j_i + [a] < 3 </script></span></p>
+<p><span><span class="MathJax_Preview"> v_t *\frac{1}{2}* j_i + [a] &lt; 3 </span><script type="math/tex; mode=display"> v_t *\frac{1}{2}* j_i + [a] < 3 </script></span></p>'''  # noqa: E501
         text = inspect.getdoc(self._docmodule.latex_math)
         html = to_html(text, module=self._module, link=self._link, latex_math=True)
         self.assertEqual(html, expected)

--- a/pdoc/test/example_pkg/__init__.py
+++ b/pdoc/test/example_pkg/__init__.py
@@ -284,3 +284,16 @@ doctests = Docformats.doctests
 
 
 reST_directives = Docformats.reST_directives
+
+
+def latex_math():
+    """
+    Inline equation: \\( v_t *\\frac{1}{2}* j_i + [a](#b) < 3 \\).
+
+    Block equation: \\[ v_t *\\frac{1}{2}* j_i + [a](#b) < 3 \\]
+
+    Block equation: $$ v_t *\\frac{1}{2}* j_i + [a](#b) < 3 $$
+
+    ..math::
+        v_t *\\frac{1}{2}* j_i + [a](#b) < 3
+    """

--- a/pdoc/test/example_pkg/__init__.py
+++ b/pdoc/test/example_pkg/__init__.py
@@ -288,12 +288,12 @@ reST_directives = Docformats.reST_directives
 
 def latex_math():
     """
-    Inline equation: \\( v_t *\\frac{1}{2}* j_i + [a](#b) < 3 \\).
+    Inline equation: \\( v_t *\\frac{1}{2}* j_i + [a] < 3 \\).
 
-    Block equation: \\[ v_t *\\frac{1}{2}* j_i + [a](#b) < 3 \\]
+    Block equation: \\[ v_t *\\frac{1}{2}* j_i + [a] < 3 \\]
 
-    Block equation: $$ v_t *\\frac{1}{2}* j_i + [a](#b) < 3 $$
+    Block equation: $$ v_t *\\frac{1}{2}* j_i + [a] < 3 $$
 
     ..math::
-        v_t *\\frac{1}{2}* j_i + [a](#b) < 3
+        v_t *\\frac{1}{2}* j_i + [a] < 3
     """


### PR DESCRIPTION
Fixes https://github.com/pdoc3/pdoc/issues/70.

Includes new `latex_math=False` config option.