### PR TITLE
Allow compatibility with pre-commit

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,8 @@
+-   id: pdoc
+    name: pdoc
+    description: 'pdoc: Auto-generate API documentation for Python projects'
+    entry: pdoc
+    language: python
+    language_version: python3
+    require_serial: true
+    types: [python]


### PR DESCRIPTION
Adding the config file would allow to simply call pdoc on a [pre-commit hook](https://github.com/pre-commit/pre-commit).