### PR TITLE
Bug Fix: Producing markdown output currently fails

### DIFF
--- a/pdoc/templates/text.mako
+++ b/pdoc/templates/text.mako
@@ -13,7 +13,7 @@
 
 <%def name="function(func)" buffered="True">
     <%
-        returns = show_type_annotations and f.return_annotation() or ''
+        returns = show_type_annotations and func.return_annotation() or ''
         if returns:
             returns = ' -> ' + returns
     %>


### PR DESCRIPTION
Fix incorrect variable reference when producing mark down output and having type annotation