### PR TITLE
ENH: include root `index.html` in `--html` output

### DIFF
--- a/pdoc/__init__.py
+++ b/pdoc/__init__.py
@@ -105,7 +105,8 @@ def _render_template(template_name, **kwargs):
         config.update((var, getattr(config_module, var, None))
                       for var in config_module.__dict__
                       if var not in MAKO_INTERNALS)
-    known_keys = set(config) | {'module', 'modules', 'http_server', 'external_links'}  # deprecated
+    known_keys = set(config) | {'module', 'modules', 'http_server',
+                                'html_index', 'external_links'}  # deprecated
     invalid_keys = {k: v for k, v in kwargs.items() if k not in known_keys}
     if invalid_keys:
         warn('Unknown configuration variables (not in config.mako): {}'.format(invalid_keys))

--- a/pdoc/cli.py
+++ b/pdoc/cli.py
@@ -487,6 +487,25 @@ or similar, at your own discretion.""",
             # Two blank lines between two modules' texts
             sys.stdout.write(os.linesep * (1 + 2 * int(module != modules[-1])))
 
+    # Add the root index.html at the top level
+    if args.html:
+        # The template expects `modules` to be Tuples of (name, docstring)
+        module_tuples = sorted((module.name, module.docstring)
+                               for module in modules)
+        index_text = pdoc._render_template('/html.mako',
+                                           modules=module_tuples,
+                                           **template_config)
+        index_file = path.join(args.output_dir, 'index.html')
+        try:
+            with open(index_file, 'w+', encoding='utf-8') as w:
+                w.write(index_text)
+        except Exception:
+            try:
+                os.unlink(index_file)
+            except Exception:
+                pass
+            raise
+
 
 if __name__ == "__main__":
     main(parser.parse_args())

--- a/pdoc/cli.py
+++ b/pdoc/cli.py
@@ -486,7 +486,7 @@ or similar, at your own discretion.""",
     for module in modules:
         if args.html:
             _quit_if_module_exists(module, ext='.html')
-            write_files(module, ext='.html', **template_config)
+            write_files(module, ext='.html', html_index=args.html_index, **template_config)
         elif args.output_dir:  # Generate text files
             _quit_if_module_exists(module, ext='.md')
             write_files(module, ext='.md', **template_config)

--- a/pdoc/cli.py
+++ b/pdoc/cli.py
@@ -83,6 +83,11 @@ aa(
          "(default: ./html for --html).",
 )
 aa(
+    "--html-index",
+    action="store_true",
+    help="Make a top-level index.html listing all the documented packages."
+)
+aa(
     "--html-no-source",
     action="store_true",
     help=argparse.SUPPRESS,
@@ -487,9 +492,9 @@ or similar, at your own discretion.""",
             # Two blank lines between two modules' texts
             sys.stdout.write(os.linesep * (1 + 2 * int(module != modules[-1])))
 
-    # Add the root index.html at the top level
-    if args.html:
-        # The template expects `modules` to be Tuples of (name, docstring)
+    if args.html and args.html_index:
+        # Add the root index.html at the top level.
+        # The template expects `modules` to be Tuples of (name, docstring).
         module_tuples = sorted((module.name, module.docstring)
                                for module in modules)
         index_text = pdoc._render_template('/html.mako',

--- a/pdoc/templates/html.mako
+++ b/pdoc/templates/html.mako
@@ -100,7 +100,7 @@
   </%def>
 
   <header>
-  % if http_server:
+  % if http_server or html_index:
     <nav class="http-server-breadcrumbs">
       <a href="/">All packages</a>
       <% parts = module.name.split('.')[:-1] %>

--- a/pdoc/test/__init__.py
+++ b/pdoc/test/__init__.py
@@ -226,10 +226,18 @@ class CliTest(unittest.TestCase):
                 self._basic_html_assertions(
                     ['index.html', 'module.html', 'subpkg2',
                      'subpkg2/index.html', 'subpkg2/module.html'])
-                # And 'index.html' should be the Python module list
+                # 'index.html' should be the Python module list
                 with open('index.html') as f:
                     contents = f.read()
                     self.assertIn('Python module list', contents)
+                # 'module.html' should have link to 'All packages'
+                with open('module.html') as f:
+                    contents = f.read()
+                    self.assertIn('All packages', contents)
+                # 'subpkg2/index.html' should have link to 'All packages'
+                with open('subpkg2/index.html') as f:
+                    contents = f.read()
+                    self.assertIn('All packages', contents)
 
     def test_html_no_source(self):
         with self.assertWarns(DeprecationWarning),\

--- a/pdoc/test/__init__.py
+++ b/pdoc/test/__init__.py
@@ -92,7 +92,6 @@ class CliTest(unittest.TestCase):
     Command-line interface unit tests.
     """
     ALL_FILES = [
-        'index.html',
         'example_pkg',
         'example_pkg/index.html',
         'example_pkg/index.m.html',
@@ -122,10 +121,6 @@ class CliTest(unittest.TestCase):
         files = glob(file_pattern, recursive=True)
         assert files
         for file in files:
-            # EARLY CONTINUE
-            if file == 'index.html':
-                # The root index.html is a special snowflake. Skip it.
-                continue
             with open(file) as f:
                 contents = f.read()
                 for pattern in include_patterns:
@@ -173,13 +168,9 @@ class CliTest(unittest.TestCase):
         package_files = {
             '': self.PUBLIC_FILES,
             '.subpkg2': [f for f in self.PUBLIC_FILES
-                         if ('subpkg2' in f
-                             or f == EXAMPLE_MODULE
-                             or f == 'index.html')],
+                         if 'subpkg2' in f or f == EXAMPLE_MODULE],
             '._private': [f for f in self.ALL_FILES
-                          if (EXAMPLE_MODULE + '/_private' in f
-                              or f == EXAMPLE_MODULE
-                              or f == 'index.html')],
+                          if EXAMPLE_MODULE + '/_private' in f or f == EXAMPLE_MODULE],
         }
         for package, expected_files in package_files.items():
             with self.subTest(package=package):
@@ -188,8 +179,8 @@ class CliTest(unittest.TestCase):
                     self._check_files(include_patterns, exclude_patterns)
 
         filenames_files = {
-            ('module.py',): ['index.html', 'module.html'],
-            ('module.py', 'subpkg2'): ['index.html', 'module.html', 'subpkg2',
+            ('module.py',): ['module.html'],
+            ('module.py', 'subpkg2'): ['module.html', 'subpkg2',
                                        'subpkg2/index.html', 'subpkg2/module.html'],
         }
         with chdir(TESTS_BASEDIR):
@@ -204,8 +195,7 @@ class CliTest(unittest.TestCase):
         with chdir(TESTS_BASEDIR):
             with run_html(EXAMPLE_MODULE + '/module.py', EXAMPLE_MODULE + '/subpkg2'):
                 self._basic_html_assertions(
-                    ['index.html', 'module.html', 'subpkg2',
-                     'subpkg2/index.html', 'subpkg2/module.html'])
+                    ['module.html', 'subpkg2', 'subpkg2/index.html', 'subpkg2/module.html'])
 
     def test_html_identifier(self):
         for package in ('', '._private'):
@@ -364,8 +354,7 @@ class CliTest(unittest.TestCase):
             run(EXAMPLE_MODULE, output_dir=path)
             with chdir(path):
                 self._basic_html_assertions([file.replace('.html', '.md')
-                                             for file in self.PUBLIC_FILES
-                                             if file != 'index.html'])
+                                             for file in self.PUBLIC_FILES])
 
     def test_google_analytics(self):
         expected = ['google-analytics.com']

--- a/pdoc/test/__init__.py
+++ b/pdoc/test/__init__.py
@@ -216,6 +216,20 @@ class CliTest(unittest.TestCase):
                 ],
             )
 
+    def test_html_index(self):
+        with chdir(TESTS_BASEDIR):
+            # Given the --html-index option
+            with run_html('--html-index',
+                          EXAMPLE_MODULE + '/module.py', EXAMPLE_MODULE + '/subpkg2'):
+                # Should have 'index.html' in addition to the normal output
+                self._basic_html_assertions(
+                    ['index.html', 'module.html', 'subpkg2',
+                     'subpkg2/index.html', 'subpkg2/module.html'])
+                # And 'index.html' should be the Python module list
+                with open('index.html') as f:
+                    contents = f.read()
+                    self.assertIn('Python module list', contents)
+
     def test_html_no_source(self):
         with self.assertWarns(DeprecationWarning),\
                 run_html(EXAMPLE_MODULE, html_no_source=None):

--- a/pdoc/test/__init__.py
+++ b/pdoc/test/__init__.py
@@ -14,6 +14,7 @@ from glob import glob
 from io import StringIO
 from itertools import chain
 from random import randint
+from shutil import rmtree
 from tempfile import TemporaryDirectory
 from time import sleep
 from unittest.mock import patch
@@ -245,6 +246,22 @@ class CliTest(unittest.TestCase):
 
             with redirect_streams() as (stdout, stderr):
                 returncode = run(EXAMPLE_MODULE, html=None, force=None, output_dir=os.getcwd())
+                self.assertEqual(returncode, 0)
+                self.assertEqual(stderr.getvalue(), '')
+
+    def test_force_with_html_index(self):
+        with run_html('--html-index', EXAMPLE_MODULE):
+            # Remove everything but index.html ensure it's failing because of index.html
+            rmtree(EXAMPLE_MODULE)
+            with redirect_streams() as (stdout, stderr):
+                returncode = run('--html-index',
+                                 EXAMPLE_MODULE, _check=False, html=None, output_dir=os.getcwd())
+                self.assertNotEqual(returncode, 0)
+                self.assertNotEqual(stderr.getvalue(), '')
+
+            with redirect_streams() as (stdout, stderr):
+                returncode = run('--html-index',
+                                 EXAMPLE_MODULE, html=None, force=None, output_dir=os.getcwd())
                 self.assertEqual(returncode, 0)
                 self.assertEqual(stderr.getvalue(), '')
 


### PR DESCRIPTION
Implements #101 .

It adds the root `index.html` from the `--http` mode to the static `--html` output.

To avoid breaking people's automations, I've put this feature behind a flag (`--html-index`) and left the default behavior alone.

I also added the breadcrumbs to the module pages when `--html-index` is active.

You can use as much or as little of this as you want. I did this in several small commits so you can see all the options side-by-side.  

**What's left**
- [x] put the feature behind a flag
- [x] check for file existence like the rest of the files do
- [x] write tests for the new flag
- [x] include breadcrumbs