### PR TITLE
Sort subclasses for cross-platform consistency

### DIFF
--- a/pdoc/__init__.py
+++ b/pdoc/__init__.py
@@ -476,7 +476,7 @@ class Doc:
         return top
 
     def __lt__(self, other):
-        return self.name < other.name
+        return self.refname < other.refname
 
 
 class Module(Doc):
@@ -882,9 +882,8 @@ class Class(Doc):
         The objects in the list are of type `pdoc.Class` if available,
         and `pdoc.External` otherwise.
         """
-        return sorted((self.module.find_class(c)
-                       for c in type.__subclasses__(self.obj)),
-                      key=lambda x: x.refname)
+        return sorted(self.module.find_class(c)
+                      for c in type.__subclasses__(self.obj))
 
     def params(self, *, annotate=False, link=None) -> List['str']:
         """

--- a/pdoc/__init__.py
+++ b/pdoc/__init__.py
@@ -882,8 +882,9 @@ class Class(Doc):
         The objects in the list are of type `pdoc.Class` if available,
         and `pdoc.External` otherwise.
         """
-        return [self.module.find_class(c)
-                for c in type.__subclasses__(self.obj)]
+        return sorted((self.module.find_class(c)
+                       for c in type.__subclasses__(self.obj)),
+                      key=lambda x: x.refname)
 
     def params(self, *, annotate=False, link=None) -> List['str']:
         """

--- a/pdoc/test/__init__.py
+++ b/pdoc/test/__init__.py
@@ -568,11 +568,22 @@ class ApiTest(unittest.TestCase):
         class D(B):
             pass
 
+        class G(C):
+            pass
+
+        class F(C):
+            pass
+
+        class E(C):
+            pass
+
         mod = pdoc.Module(pdoc)
         self.assertEqual([x.refname for x in pdoc.Class('A', mod, A).subclasses()],
                          [mod.find_class(C).refname])
         self.assertEqual([x.refname for x in pdoc.Class('B', mod, B).subclasses()],
                          [mod.find_class(D).refname])
+        self.assertEqual([x.refname for x in pdoc.Class('C', mod, C).subclasses()],
+                         [mod.find_class(x).refname for x in (E, F, G)])
 
     def test_link_inheritance(self):
         mod = pdoc.Module(EXAMPLE_MODULE)


### PR DESCRIPTION
The sort order for subclasses is inconsistent between platforms. As a
result, projects that include generated docs in their repos see diffs to
the generated files based on the platform of the contributor. This PR adds
an explicit sort so we have a deterministic order of subclasses.