### PR TITLE
allow seaborn-style params like {x,y}_partial

### DIFF
--- a/pdoc/html_helpers.py
+++ b/pdoc/html_helpers.py
@@ -166,7 +166,9 @@ class _ToMarkdown:
                           r'(?P<desc>(?:\n(?: {4}.*|$))*)',
                           _ToMarkdown._numpy_params, body, flags=re.MULTILINE)
         else:
-            body = re.sub(r'^(?P<name>\*{0,2}\w+(?:, \*{0,2}\w+)*)'
+            name = r'(?:\w|\{\w+(?:,\w+)+\})+'
+
+            body = re.sub(r'^(?P<name>\*{0,2}' + name + r'(?:, \*{0,2}' + name + r')*)'
                           r'(?: ?: (?P<type>.*))?(?<!\.)$'
                           r'(?P<desc>(?:\n(?: {4}.*|$))*)',
                           _ToMarkdown._numpy_params, body, flags=re.MULTILINE)

--- a/pdoc/html_helpers.py
+++ b/pdoc/html_helpers.py
@@ -166,8 +166,7 @@ class _ToMarkdown:
                           r'(?P<desc>(?:\n(?: {4}.*|$))*)',
                           _ToMarkdown._numpy_params, body, flags=re.MULTILINE)
         else:
-            name = r'(?:\w|\{\w+(?:,\w+)+\})+'
-
+            name = r'(?:\w|\{\w+(?:,\w+)+\})+'  # Support curly brace expansion
             body = re.sub(r'^(?P<name>\*{0,2}' + name + r'(?:, \*{0,2}' + name + r')*)'
                           r'(?: ?: (?P<type>.*))?(?<!\.)$'
                           r'(?P<desc>(?:\n(?: {4}.*|$))*)',

--- a/pdoc/test/__init__.py
+++ b/pdoc/test/__init__.py
@@ -939,19 +939,17 @@ description of <code>x1</code>, <code>x2</code>.</p>
         self.assertEqual(html, expected)
 
     def test_numpy_curly_brace_expansion(self):
-        # see https://github.com/mwaskom/seaborn/blob/
-        # 66191d8a179f1bfa42f03749bc4a07e1c0c08156/seaborn/regression.py#L514
+        # See: https://github.com/mwaskom/seaborn/blob/66191d8a179f1bfa42f03749bc4a07e1c0c08156/seaborn/regression.py#L514  # noqa: 501
         text = '''Parameters
 ----------
-{x,y}_partial : str
-some description
+prefix_{x,y}_partial : str
+    some description
 '''
         expected = '''<h2 id="parameters">Parameters</h2>
 <dl>
-<dt><strong><code>{x,y}_partial</code></strong> :&ensp;<code>str</code></dt>
-<dd>&nbsp;</dd>
-</dl>
-<p>some description</p>'''
+<dt><strong><code>prefix_{x,y}_partial</code></strong> :&ensp;<code>str</code></dt>
+<dd>some description</dd>
+</dl>'''
         html = to_html(text, module=self._module, link=self._link)
         self.assertEqual(html, expected)
 

--- a/pdoc/test/__init__.py
+++ b/pdoc/test/__init__.py
@@ -938,6 +938,23 @@ description of <code>x1</code>, <code>x2</code>.</p>
         html = to_html(text, module=self._module, link=self._link)
         self.assertEqual(html, expected)
 
+    def test_numpy_curly_brace_expansion(self):
+        # see https://github.com/mwaskom/seaborn/blob/
+        # 66191d8a179f1bfa42f03749bc4a07e1c0c08156/seaborn/regression.py#L514
+        text = '''Parameters
+----------
+{x,y}_partial : str
+some description
+'''
+        expected = '''<h2 id="parameters">Parameters</h2>
+<dl>
+<dt><strong><code>{x,y}_partial</code></strong> :&ensp;<code>str</code></dt>
+<dd>&nbsp;</dd>
+</dl>
+<p>some description</p>'''
+        html = to_html(text, module=self._module, link=self._link)
+        self.assertEqual(html, expected)
+
     def test_google(self):
         expected = '''<p>Summary line.
 Nomatch:</p>


### PR DESCRIPTION
This allows parameters to use curly brackets like seaborn does, e.g. `{x,y}_partial` to mean both `x_partial` and `y_partial`.

One example is here (but they are all over the place in seaborn): 

https://github.com/mwaskom/seaborn/blob/66191d8a179f1bfa42f03749bc4a07e1c0c08156/seaborn/regression.py#L514

This also turns up in their rendered docs as:

```
{x,y}_partial : strings in data or matrices
Confounding variables to regress out of the x or y variables before plotting.
```
(see https://seaborn.pydata.org/generated/seaborn.lmplot.html#seaborn.lmplot)


