### PR TITLE
allow wrapped lines in "see also" numpy section

### DIFF
--- a/pdoc/html_helpers.py
+++ b/pdoc/html_helpers.py
@@ -150,6 +150,10 @@ class _ToMarkdown:
         return ', '.join('`{}`'.format(i) for i in simple_list.split(', '))
 
     @staticmethod
+    def _numpy_unwrap(body):
+        return re.sub(r'\n\s{4}\s*', ' ', body)  # Handle line continuation
+
+    @staticmethod
     def _numpy_sections(match):
         """
         Convert sections with parameter, return, and see also lists to Markdown
@@ -158,7 +162,7 @@ class _ToMarkdown:
         section, body = match.groups()
         if section.title() == 'See Also':
             body = re.sub(r'^((?:\n?[\w.]* ?: .*)+)|(.*\w.*)',
-                          _ToMarkdown._numpy_seealso, body)
+                          _ToMarkdown._numpy_seealso, _ToMarkdown._numpy_unwrap(body))
         elif section.title() in ('Returns', 'Yields', 'Raises', 'Warns'):
             body = re.sub(r'^(?:(?P<name>\*{0,2}\w+(?:, \*{0,2}\w+)*)'
                           r'(?: ?: (?P<type>.*))|'

--- a/pdoc/html_helpers.py
+++ b/pdoc/html_helpers.py
@@ -150,10 +150,6 @@ class _ToMarkdown:
         return ', '.join('`{}`'.format(i) for i in simple_list.split(', '))
 
     @staticmethod
-    def _numpy_unwrap(body):
-        return re.sub(r'\n\s{4}\s*', ' ', body)  # Handle line continuation
-
-    @staticmethod
     def _numpy_sections(match):
         """
         Convert sections with parameter, return, and see also lists to Markdown
@@ -161,8 +157,9 @@ class _ToMarkdown:
         """
         section, body = match.groups()
         if section.title() == 'See Also':
+            body = re.sub(r'\n\s{4}\s*', ' ', body)  # Handle line continuation
             body = re.sub(r'^((?:\n?[\w.]* ?: .*)+)|(.*\w.*)',
-                          _ToMarkdown._numpy_seealso, _ToMarkdown._numpy_unwrap(body))
+                          _ToMarkdown._numpy_seealso, body)
         elif section.title() in ('Returns', 'Yields', 'Raises', 'Warns'):
             body = re.sub(r'^(?:(?P<name>\*{0,2}\w+(?:, \*{0,2}\w+)*)'
                           r'(?: ?: (?P<type>.*))|'

--- a/pdoc/test/__init__.py
+++ b/pdoc/test/__init__.py
@@ -930,6 +930,11 @@ description of <code>x1</code>, <code>x2</code>.</p>
 <dt><a><code>scipy.random.norm</code></a></dt>
 <dd>Random variates, PDFs, etc.</dd>
 </dl>
+<h2 id="see-also_2">See Also</h2>
+<dl>
+<dt><a><code>pdoc.Doc</code></a></dt>
+<dd>A class description that spans several lines.</dd>
+</dl>
 <h2 id="notes">Notes</h2>
 <p>Foo bar.</p>
 <h3 id="h3-title">H3 Title</h3>

--- a/pdoc/test/__init__.py
+++ b/pdoc/test/__init__.py
@@ -929,9 +929,6 @@ description of <code>x1</code>, <code>x2</code>.</p>
 <dd>Function a with its description.</dd>
 <dt><a><code>scipy.random.norm</code></a></dt>
 <dd>Random variates, PDFs, etc.</dd>
-</dl>
-<h2 id="see-also_2">See Also</h2>
-<dl>
 <dt><a><code>pdoc.Doc</code></a></dt>
 <dd>A class description that spans several lines.</dd>
 </dl>

--- a/pdoc/test/example_pkg/__init__.py
+++ b/pdoc/test/example_pkg/__init__.py
@@ -183,9 +183,6 @@ class Docformats:
         --------
         pdoc.text : Function a with its description.
         scipy.random.norm : Random variates, PDFs, etc.
-
-        See Also
-        --------
         pdoc.Doc : A class description that
                    spans several lines.
 

--- a/pdoc/test/example_pkg/__init__.py
+++ b/pdoc/test/example_pkg/__init__.py
@@ -184,6 +184,11 @@ class Docformats:
         pdoc.text : Function a with its description.
         scipy.random.norm : Random variates, PDFs, etc.
 
+        See Also
+        --------
+        pdoc.Doc : A class description that
+                   spans several lines.
+
         Notes
         -----
         Foo bar.


### PR DESCRIPTION
This is to allow multiline comments in numpy "See Also" sections.

Here's an example from the wild from seaborn:
https://github.com/mwaskom/seaborn/blob/66191d8a179f1bfa42f03749bc4a07e1c0c08156/seaborn/axisgrid.py#L2204

Currently, pdoc renders this as:

<img width="595" alt="old" src="https://user-images.githubusercontent.com/11859538/71407869-8e914600-263c-11ea-94a5-b30b44cfc3ab.png">

With this PR, this is rendered as:

<img width="579" alt="new" src="https://user-images.githubusercontent.com/11859538/71407884-9b159e80-263c-11ea-81f2-4b9e3a6122b3.png">
