### PR TITLE
Allow whitelisting using __pdoc__

### DIFF
--- a/pdoc/__init__.py
+++ b/pdoc/__init__.py
@@ -279,10 +279,9 @@ def _is_whitelisted(ident_name, module):
     Returns `True` if `ident_name` is contained in the module's __pdoc__ 
     with a value of `True`.
     """
-    if module:
-        pdoc = getattr(module, "__pdoc__", {})
-        if ident_name in pdoc and pdoc[ident_name] is True:
-            return True
+    pdoc = getattr(module, "__pdoc__", {})
+    if ident_name in pdoc and pdoc[ident_name]:
+        return True
 
 def _is_public(ident_name):
     """
@@ -661,6 +660,8 @@ class Module(Doc):
                         del self._context[key]
 
                 continue
+
+            # Prevent the ValueError below in case of whitelisting with "True"
             if docstring is True:
                 continue
 

--- a/pdoc/__init__.py
+++ b/pdoc/__init__.py
@@ -267,13 +267,8 @@ def _pep224_docstrings(doc_obj: Union['Module', 'Class'], *,
         else:
             continue
 
-        if not _is_public(name):
-            if isinstance(doc_obj, Class):
-                w_name = ".".join((doc_obj.name, name))
-            else:
-                w_name = name
-            if not _is_whitelisted(w_name, doc_obj.module):
-                continue
+        if not _is_public(name) and not _is_whitelisted(name, doc_obj):
+            continue
 
         docstring = inspect.cleandoc(str_node.value.s).strip()
         if not docstring:
@@ -284,25 +279,18 @@ def _pep224_docstrings(doc_obj: Union['Module', 'Class'], *,
     return vars, instance_vars
 
 
-def _is_whitelisted(ident_name, doc_module):
+def _is_whitelisted(name: str, doc_obj: Union['Module', 'Class']):
     """
-    Returns `True` if `ident_name` is contained in the module's __pdoc__
-    with a value of `True`.
+    Returns `True` if `name` (relative or absolute refname) is
+    contained in some module's __pdoc__ with a truish value.
     """
-    # Check this objects module's __pdoc__ for both the relative and
-    # full canonical name
-    module_basename = doc_module.name.split(".")[-1]
-    pdoc = getattr(doc_module.obj, "__pdoc__", {})
-    if pdoc.get(ident_name, False) or \
-            pdoc.get("{}.{}".format(module_basename, ident_name), False):
-        return True
-
-    # We also need to check all potential supermodules' __pdoc__s
-    # due to full reference
-    if doc_module.supermodule:
-        new_ident = "{}.{}".format(module_basename, ident_name)
-        return _is_whitelisted(new_ident, doc_module.supermodule)
-
+    refname = doc_obj.refname + '.' + name
+    module = doc_obj.module
+    while module:
+        qualname = refname[len(module.refname) + 1:]
+        if module.__pdoc__.get(qualname) or module.__pdoc__.get(refname):
+            return True
+        module = module.supermodule
     return False
 
 
@@ -578,8 +566,7 @@ class Module(Doc):
 
             public_objs = [(name, inspect.unwrap(obj))
                            for name, obj in inspect.getmembers(self.obj)
-                           if ((_is_public(name) or
-                                _is_whitelisted(name, self.module)) and
+                           if ((_is_public(name) or _is_whitelisted(name, self)) and
                                (is_from_this_module(obj) or name in var_docstrings))]
             index = list(self.obj.__dict__).index
             public_objs.sort(key=lambda i: index(i[0]))
@@ -618,7 +605,7 @@ class Module(Doc):
                     continue
 
                 # Ignore if it isn't exported
-                if not _is_public(root) and not _is_whitelisted(root, self.module):
+                if not _is_public(root) and not _is_whitelisted(root, self):
                     continue
 
                 assert self.refname == self.name
@@ -645,6 +632,11 @@ class Module(Doc):
                 self._context.update((obj.refname, obj)
                                      for obj in docobj.doc.values())
 
+    @property
+    def __pdoc__(self):
+        """This module's __pdoc__ dict, or an empty dict if none."""
+        return getattr(self.obj, '__pdoc__', {})
+
     def _link_inheritance(self):
         # Inherited members are already in place since
         # `Class._fill_inheritance()` has been called from
@@ -657,7 +649,12 @@ class Module(Doc):
             # errors if `pdoc.link_inheritance()` is called multiple times.
             return
 
-        for name, docstring in getattr(self.obj, "__pdoc__", {}).items():
+        # Apply __pdoc__ overrides
+        for name, docstring in self.__pdoc__.items():
+            # In case of whitelisting with "True", there's nothing to do
+            if docstring is True:
+                continue
+
             refname = "%s.%s" % (self.refname, name)
             if docstring in (False, None):
                 if docstring is None:
@@ -682,10 +679,6 @@ class Module(Doc):
                     if key.startswith(refname + '.'):
                         del self._context[key]
 
-                continue
-
-            # Prevent the ValueError below in case of whitelisting with "True"
-            if docstring is True:
                 continue
 
             dobj = self.find_ident(refname)
@@ -836,9 +829,8 @@ class Class(Doc):
                        for _name, obj in inspect.getmembers(self.obj)
                        # Filter only *own* members. The rest are inherited
                        # in Class._fill_inheritance()
-                       if _name in self.obj.__dict__ and
-                       (_is_public(_name) or _is_whitelisted("{}.{}".format(
-                           name, _name), self.module))]
+                       if _name in self.obj.__dict__
+                       and (_is_public(_name) or _is_whitelisted(_name, self))]
         index = list(self.obj.__dict__).index
         public_objs.sort(key=lambda i: index(i[0]))
 
@@ -932,7 +924,7 @@ class Class(Doc):
         name = self.name + '.__init__'
         qualname = self.qualname + '.__init__'
         refname = self.refname + '.__init__'
-        exclusions = getattr(self.module.obj, "__pdoc__", {})
+        exclusions = self.module.__pdoc__
         if name in exclusions or qualname in exclusions or refname in exclusions:
             return []
 
@@ -1030,9 +1022,7 @@ class Class(Doc):
             try:
                 dobj = self.doc[name]
             except KeyError:
-                # There is a key in __pdoc__ blocking this member
-                assert any(i.endswith(self.qualname + '.' + name)
-                           for i in self.module.obj.__pdoc__)
+                # There is a key in some __pdoc__ dict blocking this member
                 continue
             if (dobj.obj is parent_dobj.obj or
                     (dobj.docstring or parent_dobj.docstring) == parent_dobj.docstring):

--- a/pdoc/__init__.py
+++ b/pdoc/__init__.py
@@ -827,7 +827,8 @@ class Class(Doc):
                        # Filter only *own* members. The rest are inherited
                        # in Class._fill_inheritance()
                        if _name in self.obj.__dict__ and
-                       (_is_public(_name) or _is_whitelisted("{}.{}".format(name, _name), self.module))]
+                       (_is_public(_name) or _is_whitelisted("{}.{}".format(
+                           name, _name), self.module))]
         index = list(self.obj.__dict__).index
         public_objs.sort(key=lambda i: index(i[0]))
 

--- a/pdoc/__init__.py
+++ b/pdoc/__init__.py
@@ -268,7 +268,12 @@ def _pep224_docstrings(doc_obj: Union['Module', 'Class'], *,
             continue
 
         if not _is_public(name):
-            continue
+            if isinstance(doc_obj, Class):
+                w_name = ".".join((doc_obj.name, name))
+            else:
+                w_name = name
+            if not _is_whitelisted(w_name, doc_obj.module):
+                continue
 
         docstring = inspect.cleandoc(str_node.value.s).strip()
         if not docstring:

--- a/pdoc/__init__.py
+++ b/pdoc/__init__.py
@@ -274,13 +274,13 @@ def _pep224_docstrings(doc_obj: Union['Module', 'Class'], *,
 
     return vars, instance_vars
 
+
 def _is_whitelisted(ident_name, doc_obj):
     """
-    Returns `True` if `ident_name` is contained in the module's __pdoc__ 
+    Returns `True` if `ident_name` is contained in the module's __pdoc__
     with a value of `True`.
     """
-
-    # Check this objects module's __pdoc__ for both the relative and 
+    # Check this objects module's __pdoc__ for both the relative and
     # full canonical name
     module_basename = doc_obj.module.name.split(".")[-1]
     pdoc = getattr(doc_obj.module.obj, "__pdoc__", {})
@@ -293,8 +293,9 @@ def _is_whitelisted(ident_name, doc_obj):
     if hasattr(doc_obj.module, "supermodule") and doc_obj.module.supermodule:
         new_ident = "{}.{}".format(module_basename, ident_name)
         return _is_whitelisted(new_ident, doc_obj.module.supermodule)
-    
+
     return False
+
 
 def _is_public(ident_name):
     """
@@ -568,12 +569,11 @@ class Module(Doc):
 
             public_objs = [(name, inspect.unwrap(obj))
                            for name, obj in inspect.getmembers(self.obj)
-                           if ((_is_public(name) or 
+                           if ((_is_public(name) or
                                 _is_whitelisted(name, self)) and
                                (is_from_this_module(obj) or name in var_docstrings))]
             index = list(self.obj.__dict__).index
             public_objs.sort(key=lambda i: index(i[0]))
-
 
         for name, obj in public_objs:
             if _is_function(obj):
@@ -826,9 +826,8 @@ class Class(Doc):
                        for _name, obj in inspect.getmembers(self.obj)
                        # Filter only *own* members. The rest are inherited
                        # in Class._fill_inheritance()
-                       if _name in self.obj.__dict__ and 
-                                (_is_public(_name) or 
-                                _is_whitelisted("{}.{}".format(name, _name), self))]
+                       if _name in self.obj.__dict__ and
+                       (_is_public(_name) or _is_whitelisted("{}.{}".format(name, _name), self))]
         index = list(self.obj.__dict__).index
         public_objs.sort(key=lambda i: index(i[0]))
 

--- a/pdoc/documentation.md
+++ b/pdoc/documentation.md
@@ -142,7 +142,7 @@ Class and instance variables can also [inherit docstrings].
 
 Overriding docstrings with `__pdoc__`
 -------------------------------------
-Docstrings for objects can be disabled or overridden with a special
+Docstrings for objects can be disabled, overridden or whitelisted with a special
 module-level dictionary `__pdoc__`. The _keys_
 should be string identifiers within the scope of the module or,
 alternatively, fully-qualified reference names. E.g. for instance
@@ -151,6 +151,12 @@ variable `self.variable` of class `C`, its module-level identifier is
 
 If `__pdoc__[key] = False`, then `key` (and its members) will be
 **excluded from the documentation** of the module.
+
+Conversely, if `__pdoc__[key] = True`, then `key` (and its members) will be
+**included in the documentation** of the module. This feature is useful for
+including the documentation of "private" definitions, i.e. classes/functions or
+variables starting with "_", including special functions such as "__call__", which
+are ignored by default.
 
 Alternatively, the _values_ of `__pdoc__` should be the overriding docstrings.
 This particular feature is useful when there's no feasible way of

--- a/pdoc/documentation.md
+++ b/pdoc/documentation.md
@@ -19,10 +19,16 @@ variables is found by examining objects' abstract syntax trees.
 
 What objects are documented?
 ----------------------------
+[public-private]: #what-objects-are-documented
 `pdoc` only extracts _public API_ documentation.[^public]
-All objects (modules, functions, classes, variables) are only
-considered public if their _identifiers don't begin with an
-underscore_ ( \_ ).[^private]
+If a module defines [`__all__`][__all__], then only
+the identifiers contained in this list are considered public.
+More generally, objects (modules, variables, functions, classes, methods)
+are only considered public in the module where they are defined
+(vs. imported from somewhere else) and only if their
+_identifiers don't begin with an underscore_ ( \_ ).[^private]
+
+This can be fine-tuned through [`__pdoc__` dict][__pdoc__].
 
 [^public]:
     Here, public API refers to the API that is made available
@@ -36,17 +42,7 @@ underscore_ ( \_ ).[^private]
 
 [a common convention]: https://docs.python.org/3/tutorial/classes.html#private-variables
 
-In addition, if a module defines [`__all__`][__all__], then only
-the identifiers contained in this list will be considered public.
-Otherwise, a module's global identifiers are considered public
-only if they don't begin with an underscore and are defined
-in this exact module (i.e. not imported from somewhere else).
-
 [__all__]: https://docs.python.org/3/tutorial/modules.html#importing-from-a-package
-
-By transitivity, sub-objects of non-public objects
-(e.g. submodules of non-public modules, methods of non-public classes etc.)
-are not public and thus not documented.
 
 
 Where does `pdoc` get documentation from?
@@ -142,25 +138,25 @@ Class and instance variables can also [inherit docstrings].
 
 Overriding docstrings with `__pdoc__`
 -------------------------------------
-Docstrings for objects can be disabled, overridden or whitelisted with a special
+[__pdoc__]: #overriding-docstrings-with-__pdoc__
+Docstrings for objects can be disabled, overridden, or whitelisted with a special
 module-level dictionary `__pdoc__`. The _keys_
 should be string identifiers within the scope of the module or,
 alternatively, fully-qualified reference names. E.g. for instance
 variable `self.variable` of class `C`, its module-level identifier is
-`'C.variable'`.
+`'C.variable'`, and `some_package.module.C.variable` its refname.
 
 If `__pdoc__[key] = False`, then `key` (and its members) will be
 **excluded from the documentation** of the module.
 
-Conversely, if `__pdoc__[key] = True`, then `key` (and its members) will be
-**included in the documentation** of the module. This feature is useful for
-including the documentation of "private" definitions, i.e. classes/functions or
-variables starting with "_", including special functions such as "__call__", which
-are ignored by default.
+Conversely, if `__pdoc__[key] = True`, then `key` (and its public members) will be
+**included in the documentation** of the module. This can be used to
+include documentation of [private objects][public-private],
+including special functions such as `__call__`, which are ignored by default.
 
-Alternatively, the _values_ of `__pdoc__` should be the overriding docstrings.
-This particular feature is useful when there's no feasible way of
-attaching a docstring to something. A good example of this is a
+Alternatively, the _values_ of `__pdoc__` can be the **overriding docstrings**.
+This feature is useful when there's no feasible way of
+attaching a docstring to something. A good example is a
 [namedtuple](https://docs.python.org/3/library/collections.html#collections.namedtuple):
 
     __pdoc__ = {}

--- a/pdoc/test/__init__.py
+++ b/pdoc/test/__init__.py
@@ -538,6 +538,8 @@ class ApiTest(unittest.TestCase):
             mod = pdoc.Module(module)
             pdoc.link_inheritance()
             self.assertIn('_private_function', mod.doc)
+            self.assertIn('subpkg', mod.doc)
+            self.assertNotIn('_private_function', mod.doc["subpkg"].doc)
 
         # Defined in example_pkg, referring to a member of its submodule
         with patch.object(module, '__pdoc__', {'subpkg.A.__call__': True}):

--- a/pdoc/test/__init__.py
+++ b/pdoc/test/__init__.py
@@ -533,6 +533,15 @@ class ApiTest(unittest.TestCase):
             pdoc.link_inheritance()
             self.assertIn('_private_function', mod.doc)
 
+        # Defined in example_pkg, referring to a member of its submodule 
+        with patch.object(module, '__pdoc__', {'subpkg.A.__call__': True}):
+            mod = pdoc.Module(module)
+            pdoc.link_inheritance()
+            self.assertIn('A', mod.doc)
+            self.assertIn('__call__', mod.doc['A'].doc)
+
+        # Using full refname
+        # with patch.object(module, '__pdoc__', {'example_pkg.subpkg.A.__call__': True}):
 
 
     def test__all__(self):

--- a/pdoc/test/__init__.py
+++ b/pdoc/test/__init__.py
@@ -522,7 +522,7 @@ class ApiTest(unittest.TestCase):
         self.assertNotIn('__call__', mod.doc['A'].doc)
         self.assertNotIn('_private_function', mod.doc)
 
-        with patch.object(module, '__pdoc__', {'A.__call__': True}):
+        with patch.object(module, '__pdoc__', {'A.__call__': "Overwrite private function doc"}):
             mod = pdoc.Module(module)
             pdoc.link_inheritance()
             self.assertIn('A', mod.doc)

--- a/pdoc/test/__init__.py
+++ b/pdoc/test/__init__.py
@@ -522,11 +522,13 @@ class ApiTest(unittest.TestCase):
         self.assertNotIn('__call__', mod.doc['A'].doc)
         self.assertNotIn('_private_function', mod.doc)
 
-        with patch.object(module, '__pdoc__', {'A.__call__': "Overwrite private function doc"}):
+        docstring = "Overwrite private function doc"
+        with patch.object(module, '__pdoc__', {'A.__call__': docstring}):
             mod = pdoc.Module(module)
             pdoc.link_inheritance()
             self.assertIn('A', mod.doc)
             self.assertIn('__call__', mod.doc['A'].doc)
+            self.assertEqual(mod.doc['A'].doc['__call__'].docstring, docstring)
 
         with patch.object(module, '__pdoc__', {'example_pkg.A.__call__': True}):
             mod = pdoc.Module(module)

--- a/pdoc/test/__init__.py
+++ b/pdoc/test/__init__.py
@@ -555,6 +555,17 @@ class ApiTest(unittest.TestCase):
             self.assertIn('A', mod.doc['subpkg'].doc)
             self.assertIn('__call__', mod.doc['subpkg'].doc['A'].doc)
 
+        # Whitelist entire modules
+        with patch.object(module, '__pdoc__', {'example_pkg._private': True}):
+            mod = pdoc.Module(module)
+            pdoc.link_inheritance()
+            self.assertIn('_private', mod.doc)
+
+        with patch.object(module, '__pdoc__', {'_private': True}):
+            mod = pdoc.Module(module)
+            pdoc.link_inheritance()
+            self.assertIn('_private', mod.doc)
+
     def test__all__(self):
         module = pdoc.import_module(EXAMPLE_MODULE + '.index')
         with patch.object(module, '__all__', ['B'], create=True):

--- a/pdoc/test/__init__.py
+++ b/pdoc/test/__init__.py
@@ -513,6 +513,28 @@ class ApiTest(unittest.TestCase):
             pdoc.Module(module)
             pdoc.link_inheritance()
 
+    def test__pdoc__whitelist(self):
+        module = pdoc.import_module(EXAMPLE_MODULE)
+
+        mod = pdoc.Module(module)
+        pdoc.link_inheritance()
+        self.assertIn('A', mod.doc)
+        self.assertNotIn('__call__', mod.doc['A'].doc)
+        self.assertNotIn('_private_function', mod.doc)
+
+        with patch.object(module, '__pdoc__', {'A.__call__': True}):
+            mod = pdoc.Module(module)
+            pdoc.link_inheritance()
+            self.assertIn('A', mod.doc)
+            self.assertIn('__call__', mod.doc['A'].doc)
+
+        with patch.object(module, '__pdoc__', {'_private_function': True}):
+            mod = pdoc.Module(module)
+            pdoc.link_inheritance()
+            self.assertIn('_private_function', mod.doc)
+
+
+
     def test__all__(self):
         module = pdoc.import_module(EXAMPLE_MODULE + '.index')
         with patch.object(module, '__all__', ['B'], create=True):
@@ -1199,3 +1221,4 @@ class HttpTest(unittest.TestCase):
 
 if __name__ == '__main__':
     unittest.main()
+    

--- a/pdoc/test/__init__.py
+++ b/pdoc/test/__init__.py
@@ -528,6 +528,12 @@ class ApiTest(unittest.TestCase):
             self.assertIn('A', mod.doc)
             self.assertIn('__call__', mod.doc['A'].doc)
 
+        with patch.object(module, '__pdoc__', {'example_pkg.A.__call__': True}):
+            mod = pdoc.Module(module)
+            pdoc.link_inheritance()
+            self.assertIn('A', mod.doc)
+            self.assertIn('__call__', mod.doc['A'].doc)
+
         with patch.object(module, '__pdoc__', {'_private_function': True}):
             mod = pdoc.Module(module)
             pdoc.link_inheritance()
@@ -537,11 +543,17 @@ class ApiTest(unittest.TestCase):
         with patch.object(module, '__pdoc__', {'subpkg.A.__call__': True}):
             mod = pdoc.Module(module)
             pdoc.link_inheritance()
-            self.assertIn('A', mod.doc)
-            self.assertIn('__call__', mod.doc['A'].doc)
+            self.assertIn('subpkg', mod.doc)
+            self.assertIn('A', mod.doc['subpkg'].doc)
+            self.assertIn('__call__', mod.doc['subpkg'].doc['A'].doc)
 
         # Using full refname
-        # with patch.object(module, '__pdoc__', {'example_pkg.subpkg.A.__call__': True}):
+        with patch.object(module, '__pdoc__', {'example_pkg.subpkg.A.__call__': True}):
+            mod = pdoc.Module(module)
+            pdoc.link_inheritance()
+            self.assertIn('subpkg', mod.doc)
+            self.assertIn('A', mod.doc['subpkg'].doc)
+            self.assertIn('__call__', mod.doc['subpkg'].doc['A'].doc)
 
 
     def test__all__(self):

--- a/pdoc/test/__init__.py
+++ b/pdoc/test/__init__.py
@@ -539,7 +539,7 @@ class ApiTest(unittest.TestCase):
             pdoc.link_inheritance()
             self.assertIn('_private_function', mod.doc)
 
-        # Defined in example_pkg, referring to a member of its submodule 
+        # Defined in example_pkg, referring to a member of its submodule
         with patch.object(module, '__pdoc__', {'subpkg.A.__call__': True}):
             mod = pdoc.Module(module)
             pdoc.link_inheritance()
@@ -554,7 +554,6 @@ class ApiTest(unittest.TestCase):
             self.assertIn('subpkg', mod.doc)
             self.assertIn('A', mod.doc['subpkg'].doc)
             self.assertIn('__call__', mod.doc['subpkg'].doc['A'].doc)
-
 
     def test__all__(self):
         module = pdoc.import_module(EXAMPLE_MODULE + '.index')
@@ -1242,4 +1241,3 @@ class HttpTest(unittest.TestCase):
 
 if __name__ == '__main__':
     unittest.main()
-    

--- a/pdoc/test/__init__.py
+++ b/pdoc/test/__init__.py
@@ -570,6 +570,13 @@ class ApiTest(unittest.TestCase):
             pdoc.link_inheritance()
             self.assertIn('_private', mod.doc)
 
+        # Whitelist private instance variables
+        with patch.object(module, '__pdoc__', {'B._private_instance_var': True}):
+            mod = pdoc.Module(module)
+            pdoc.link_inheritance()
+            self.assertIn('B', mod.doc)
+            self.assertIn('_private_instance_var', mod.doc['B'].doc)
+
     def test__all__(self):
         module = pdoc.import_module(EXAMPLE_MODULE + '.index')
         with patch.object(module, '__all__', ['B'], create=True):

--- a/pdoc/test/example_pkg/__init__.py
+++ b/pdoc/test/example_pkg/__init__.py
@@ -24,6 +24,11 @@ def object_as_arg_default(*args, a=object(), **kwargs):
     """Html-encodes angle brackets in params"""
 
 
+def _private_function():
+    """Private function, should only appear if whitelisted"""
+
+
+
 class A:
     """`A` is base class for `example_pkg.B`."""  # Test refname link
     def overridden(self):
@@ -34,6 +39,9 @@ class A:
 
     def inherited(self):  # Inherited in B
         """A.inherited docstring"""
+
+    def __call__(self):
+        """A.__call__ docstring. Only shown when whitelisted"""
 
 
 non_callable_routine = staticmethod(lambda x: 2)  # Not interpreted as Function; skipped

--- a/pdoc/test/example_pkg/__init__.py
+++ b/pdoc/test/example_pkg/__init__.py
@@ -28,7 +28,6 @@ def _private_function():
     """Private function, should only appear if whitelisted"""
 
 
-
 class A:
     """`A` is base class for `example_pkg.B`."""  # Test refname link
     def overridden(self):


### PR DESCRIPTION
This PR implements whitelisting functionality for pdoc3 (#90). If the `__pdoc__` dictionary on a module level now contains a function or class name with the boolean value True, this function/class will now also be documented, even if it is otherwise marked by as private, i.e. by starting with an '_'. Also added a testcase for this behavior.

Since I just took a quick shot at it because I run into the case that I wanted to document a `__call__` override for one of my classes, I am not sure if I missed something. 

So far I assume that the whitelisting will always be done on the module level, i.e. the `__pdoc__` should be defined there instead of inside the class/function etc and just contain the full name, e.g. `A.__call__`. I think keeping all whitelisting together in one place is better than having them spread across all classes of a module, but let me know if you disagree.

One thing that I did not add, was "private" Parameters of functions, primarily since this would have required me to change the `_params` static function in order to get the function's name there, but also because I feel like specifying these parameters may be tedious.

Happy to get your comments on this.
