### PR TITLE
Generate better docs when using pybind11

### DIFF
--- a/pdoc/__init__.py
+++ b/pdoc/__init__.py
@@ -1216,6 +1216,7 @@ class Function(Doc):
                 if strings:
                     string = filter(strings[0])
                     _locals, _globals = {}, {}
+                    _globals.update({'capsule': None})  # pybind11 capsule data type
                     _globals.update(typing.__dict__)
                     _globals.update(self.module.obj.__dict__)
                     # Trim binding module basename from type annotations

--- a/pdoc/__init__.py
+++ b/pdoc/__init__.py
@@ -1162,6 +1162,9 @@ class Function(Doc):
         try:
             signature = inspect.signature(inspect.unwrap(doc_obj.obj))
         except ValueError:
+            if doc_obj.obj.__doc__ is None:
+                return ["..."]
+
             # Extract signature from the first line of the docstring for C builtin function
             f_pattern = re.compile(r'^(?P<f_name>[a-zA-Z_]\w*)'
                                    r'\((?P<params_all>.*)\)'

--- a/pdoc/__init__.py
+++ b/pdoc/__init__.py
@@ -1132,8 +1132,8 @@ class Function(Doc):
                 annot = ''
             else:
                 annot = f_match.group("return_anno")
-                # Remove signature
-                self.docstring = f_pattern.sub('', self.obj.__doc__)
+                # Remove signature from docstring variable
+                self.docstring = f_pattern.sub('', self.docstring)
 
         if not annot:
             return ''
@@ -1199,8 +1199,8 @@ class Function(Doc):
                 param = inspect.Parameter(p_name, kind, default=p_default, annotation=p_type)
                 params_obj.append(param)
 
-            # Remove signature from docstring
-            doc_obj.docstring = f_pattern.sub('', doc_obj.obj.__doc__)
+            # Remove signature from docstring variable
+            doc_obj.docstring = f_pattern.sub('', doc_obj.docstring)
             signature = inspect.Signature(params_obj, return_annotation=return_anno)
 
         def safe_default_value(p: inspect.Parameter):

--- a/pdoc/__init__.py
+++ b/pdoc/__init__.py
@@ -835,6 +835,8 @@ class Class(Doc):
         self.doc = {}  # type: Dict[str, Union[Function, Variable]]
         """A mapping from identifier name to a `pdoc.Doc` objects."""
 
+        pdoc = getattr(obj, '__pdoc__', {})
+
         public_objs = [(name, inspect.unwrap(obj))
                        for name, obj in inspect.getmembers(self.obj)
                        # Filter only *own* members. The rest are inherited
@@ -852,10 +854,25 @@ class Class(Doc):
                     name, self.module, obj, cls=self,
                     method=not self._method_type(self.obj, name))
             else:
+                pdoc_string = None
+
+                # Check for short refname
+                refname = self.qualname + '.' + name
+                if refname in pdoc.keys():
+                    pdoc_string = pdoc[refname]
+                    if pdoc_string is False:
+                        continue
+                # Check for full refname
+                refname = self.module.name + '.' + refname
+                if refname in pdoc.keys() and not pdoc_string:
+                    pdoc_string = pdoc[refname]
+                    if pdoc_string is False:
+                        continue
+
                 self.doc[name] = Variable(
                     name, self.module,
                     docstring=(
-                        var_docstrings.get(name) or
+                        pdoc_string or var_docstrings.get(name) or
                         (inspect.isclass(obj) or _is_descriptor(obj)) and inspect.getdoc(obj)),
                     cls=self,
                     obj=getattr(obj, 'fget', getattr(obj, '__get__', None)),

--- a/pdoc/__init__.py
+++ b/pdoc/__init__.py
@@ -1158,7 +1158,7 @@ class Function(Doc):
         return self._params(self, annotate=annotate, link=link, module=self.module)
 
     @staticmethod
-    def _params(doc_obj: Doc, annotate=False, link=None, module=None):
+    def _params(doc_obj, annotate=False, link=None, module=None):
         try:
             signature = inspect.signature(inspect.unwrap(doc_obj.obj))
         except ValueError:

--- a/pdoc/__init__.py
+++ b/pdoc/__init__.py
@@ -1177,6 +1177,7 @@ class Function(Doc):
             #       This split condition handles default values like `{1, 2, 3}` or
             #       `('a', 'b', 'c')` correctly but not nested default values like
             #       `[{1, 2}, {3, 4}]`
+            # TEST: https://regex101.com/r/lfFY6O/1
             params_str = re.split(r', (?![^\[\({]*[\]\)}])', params_all)
             for param_str in params_str:
                 p_match = re.match(r'^(?P<p_kind>\*{0,2})'

--- a/pdoc/test/__init__.py
+++ b/pdoc/test/__init__.py
@@ -720,6 +720,11 @@ class ApiTest(unittest.TestCase):
         self.assertEqual(pdoc.Function('bug130', mod, bug130_str_annotation).params(annotate=True),
                          ['a:\N{NBSP}str'])
 
+        # builtin callables with signatures in docstrings
+        from itertools import repeat
+        self.assertEqual(pdoc.Function('repeat', mod, repeat).params(), ['object', 'times'])
+        self.assertEqual(pdoc.Function('slice', mod, slice).params(), ['start', 'stop', 'step'])
+
     def test_Function_return_annotation(self):
         import typing
 

--- a/pdoc/test/__init__.py
+++ b/pdoc/test/__init__.py
@@ -725,6 +725,11 @@ class ApiTest(unittest.TestCase):
         self.assertEqual(pdoc.Function('repeat', mod, repeat).params(), ['object', 'times'])
         self.assertEqual(pdoc.Function('slice', mod, slice).params(), ['start', 'stop', 'step'])
 
+        class get_sample(repeat):
+            """ get_sample(self: pdoc.int, pos: int) -> Tuple[int, float] """
+        self.assertEqual(pdoc.Function('get_sample', mod, get_sample).params(annotate=True),
+                         ['self:\xa0int', 'pos:\xa0int'])
+
     def test_Function_return_annotation(self):
         import typing
 

--- a/pdoc/test/__init__.py
+++ b/pdoc/test/__init__.py
@@ -729,6 +729,8 @@ class ApiTest(unittest.TestCase):
             """ get_sample(self: pdoc.int, pos: int) -> Tuple[int, float] """
         self.assertEqual(pdoc.Function('get_sample', mod, get_sample).params(annotate=True),
                          ['self:\xa0int', 'pos:\xa0int'])
+        self.assertEqual(pdoc.Function('get_sample', mod, get_sample).return_annotation(),
+                         'Tuple[int,\xa0float]')
 
     def test_Function_return_annotation(self):
         import typing


### PR DESCRIPTION
This two commits will generate nicer looking docs when documenting modules generated by pybind11 with no source code available:

* Use the `__pdoc__` Dict for documenting class variables.
* Parse the signature string in the first line of the docstring when available.

