### PR TITLE
BUG: Fix function parameters that shadow names from outer scope

### DIFF
--- a/pdoc/__init__.py
+++ b/pdoc/__init__.py
@@ -1172,16 +1172,19 @@ class Function(Doc):
 
             s = str(p)
             if p.annotation is not EMPTY:
+                name, annotation = s.split(':', maxsplit=1)
+                name, annotation = name.strip(), annotation.strip()
                 if sys.version_info < (3, 7):
                     # PEP8-normalize whitespace
-                    s = re.sub(r'(?<!\s)=(?!\s)', ' = ', re.sub(r':(?!\s)', ': ', s, 1), 1)
+                    annotation = re.sub(r'(?<!\s)=(?!\s)', ' = ', annotation, 1)
                 # "Eval" forward-declarations (typing string literals)
                 if isinstance(p.annotation, str):
-                    s = s.replace("'%s'" % p.annotation, p.annotation, 1)
-                s = s.replace(' ', '\N{NBSP}')  # prevent improper line breaking
+                    annotation = p.annotation
+                annotation = annotation.replace(' ', '\N{NBSP}')  # prevent improper line breaking
 
                 if link:
-                    s = re.sub(r'[\w\.]+', _linkify, s)
+                    annotation = re.sub(r'[\w\.]+', _linkify, annotation)
+                s = ':\N{NBSP}'.join((name, annotation))
 
             params.append(s)
 

--- a/pdoc/__init__.py
+++ b/pdoc/__init__.py
@@ -1182,7 +1182,8 @@ class Function(Doc):
 
                 if link:
                     annotation = inspect.formatannotation(p.annotation)
-                    s = s.replace(annotation, re.sub(r'[\w\.]+', _linkify, annotation))
+                    linked_annotation = re.sub(r'[\w\.]+', _linkify, annotation)
+                    s = linked_annotation.join(s.rsplit(annotation, 1))  # "rreplace" once
 
             params.append(s)
 

--- a/pdoc/__init__.py
+++ b/pdoc/__init__.py
@@ -1172,19 +1172,17 @@ class Function(Doc):
 
             s = str(p)
             if p.annotation is not EMPTY:
-                name, annotation = s.split(':', maxsplit=1)
-                name, annotation = name.strip(), annotation.strip()
                 if sys.version_info < (3, 7):
                     # PEP8-normalize whitespace
-                    annotation = re.sub(r'(?<!\s)=(?!\s)', ' = ', annotation, 1)
+                    s = re.sub(r'(?<!\s)=(?!\s)', ' = ', re.sub(r':(?!\s)', ': ', s, 1), 1)
                 # "Eval" forward-declarations (typing string literals)
                 if isinstance(p.annotation, str):
-                    annotation = p.annotation
-                annotation = annotation.replace(' ', '\N{NBSP}')  # prevent improper line breaking
+                    s = s.replace("'%s'" % p.annotation, p.annotation, 1)
+                s = s.replace(' ', '\N{NBSP}')  # prevent improper line breaking
 
                 if link:
-                    annotation = re.sub(r'[\w\.]+', _linkify, annotation)
-                s = ':\N{NBSP}'.join((name, annotation))
+                    annotation = inspect.formatannotation(p.annotation)
+                    s = s.replace(annotation, re.sub(r'[\w\.]+', _linkify, annotation))
 
             params.append(s)
 

--- a/pdoc/test/__init__.py
+++ b/pdoc/test/__init__.py
@@ -695,6 +695,11 @@ class ApiTest(unittest.TestCase):
                          ['a:\N{NBSP}int', '*b',
                           "c:\N{NBSP}List[<a href=\"#pdoc.Doc\">Doc</a>]\N{NBSP}=\N{NBSP}[]"])
 
+        # shadowed name
+        def f(pdoc: int): pass
+        func = pdoc.Function('f', mod, f)
+        self.assertEqual(func.params(annotate=True, link=link), ['pdoc:\N{NBSP}int'])
+
         def bug130_str_annotation(a: "str"):
             return
 


### PR DESCRIPTION
This PR fixes bug in the following situation:

```python
# pkg1/__init__.py

# assume there is a submodule named "message"
from .message import Message
# after importing "Message", "message" becomes a name in global scope

def send(message: Message):
    # previously, the "message" parameter will be rendered as a link to the "message" module
    pass
```