### PR TITLE
Fix License file name

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
     data_files=[
         (
             "share/pdoc",
-            ["README.md", "longdesc.rst", "UNLICENSE", "INSTALL", "CHANGELOG"],
+            ["README.md", "longdesc.rst", "LICENSE", "INSTALL", "CHANGELOG"],
         ),
         ("share/doc/pdoc", ["doc/pdoc/index.html"]),
     ],


### PR DESCRIPTION
pip install doesn't work because of wrong license file name