### PR TITLE
File INSTALL is missing

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
     data_files=[
         (
             "share/pdoc",
-            ["README.md", "longdesc.rst", "UNLICENSE", "INSTALL", "CHANGELOG"],
+            ["README.md", "longdesc.rst", "LICENSE", "INSTALL", "CHANGELOG"],
         ),
         ("share/doc/pdoc", ["doc/pdoc/index.html"]),
     ],

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
     data_files=[
         (
             "share/pdoc",
-            ["README.md", "longdesc.rst", "LICENSE", "INSTALL", "CHANGELOG"],
+            ["README.md", "longdesc.rst", "LICENSE", "CHANGELOG"],
         ),
         ("share/doc/pdoc", ["doc/pdoc/index.html"]),
     ],


### PR DESCRIPTION
After having fixed the License file name (https://github.com/pdoc3/pdoc/pull/155), another problem.
I should have fixed the both problems in the same pull request...