### PR TITLE
Skip subclasses which have non-str __module__ attribute

### DIFF
--- a/pdoc/__init__.py
+++ b/pdoc/__init__.py
@@ -897,7 +897,8 @@ class Class(Doc):
         and `pdoc.External` otherwise.
         """
         return sorted(self.module.find_class(c)
-                      for c in type.__subclasses__(self.obj))
+                      for c in type.__subclasses__(self.obj)
+                      if isinstance(c.__module__, str))
 
     def params(self, *, annotate=False, link=None) -> List['str']:
         """

--- a/pdoc/test/__init__.py
+++ b/pdoc/test/__init__.py
@@ -603,6 +603,10 @@ class ApiTest(unittest.TestCase):
         class E(C):
             pass
 
+        # H should not show up as a subclass of A, because it has anon-str __module__
+        # attribute
+        H = type("H", (A,), {"__module__": None})  # noqa: F841
+
         mod = pdoc.Module(pdoc)
         self.assertEqual([x.refname for x in pdoc.Class('A', mod, A).subclasses()],
                          [mod.find_class(C).refname])


### PR DESCRIPTION
I encountered a crash of pdoc on code using Pydantic's `create_model`,
which defaults to passing `__module__ = None` when creating new
subclasses. I think it's non-optimal of Pydantic to create such classes,
but I figured that it would be best for pdoc3 to be resilient to the
situation.