### PR TITLE
Include annotations for class properties

### DIFF
--- a/pdoc/templates/html.mako
+++ b/pdoc/templates/html.mako
@@ -224,7 +224,12 @@
           <h3>Instance variables</h3>
           <dl>
           % for v in inst_vars:
-              <dt id="${v.refname}"><code class="name">var ${ident(v.name)}</code></dt>
+              <%
+                  var_type = show_type_annotations and v.type_annotation(link=link) or ''
+                  if var_type:
+                      var_type = ' ->\N{NBSP}' + var_type
+              %>
+              <dt id="${v.refname}"><code class="name">var ${ident(v.name)}${var_type}</code></dt>
               <dd>${show_desc(v)}</dd>
           % endfor
           </dl>

--- a/pdoc/test/__init__.py
+++ b/pdoc/test/__init__.py
@@ -719,14 +719,13 @@ class ApiTest(unittest.TestCase):
         self.assertEqual(func.return_annotation(), 'List[Union[str,\N{NBSP}pdoc.Doc]]')
 
     @ignore_warnings
-    def test_property_type_annotation(self):
+    def test_Variable_type_annotation(self):
         import typing
 
         class Foobar:
-            """foobar"""
             @property
-            def prop() -> typing.Optional[int]:
-                """prop"""
+            def prop(self) -> typing.Optional[int]:
+                pass
 
         cls = pdoc.Class('Foobar', pdoc.Module(pdoc), Foobar)
         prop = cls.instance_variables()[0]

--- a/pdoc/test/__init__.py
+++ b/pdoc/test/__init__.py
@@ -719,6 +719,20 @@ class ApiTest(unittest.TestCase):
         self.assertEqual(func.return_annotation(), 'List[Union[str,\N{NBSP}pdoc.Doc]]')
 
     @ignore_warnings
+    def test_property_type_annotation(self):
+        import typing
+
+        class Foobar:
+            """foobar"""
+            @property
+            def prop() -> typing.Optional[int]:
+                """prop"""
+
+        cls = pdoc.Class('Foobar', pdoc.Module(pdoc), Foobar)
+        prop = cls.instance_variables()[0]
+        self.assertEqual(prop.type_annotation(), 'Union[int,\N{NBSP}NoneType]')
+
+    @ignore_warnings
     def test_Class_docstring(self):
         class A:
             """foo"""


### PR DESCRIPTION
Type annotations (when enabled) are not included in the generated documentation for members in classes marked with `@property`. This is an attempt to fix that.