### PR TITLE
Add support for python 3.8 positional only argument syntax

### DIFF
--- a/pdoc/__init__.py
+++ b/pdoc/__init__.py
@@ -1249,6 +1249,7 @@ class Function(Doc):
 
         params = []
         kw_only = False
+        pos_only = False
         EMPTY = inspect.Parameter.empty
 
         if link:
@@ -1258,6 +1259,12 @@ class Function(Doc):
         for p in signature.parameters.values():  # type: inspect.Parameter
             if not _is_public(p.name) and p.default is not EMPTY:
                 continue
+
+            if p.kind == p.POSITIONAL_ONLY:
+                pos_only = True
+            elif pos_only:
+                params.append("/")
+                pos_only = False
 
             if p.kind == p.VAR_POSITIONAL:
                 kw_only = True
@@ -1286,6 +1293,9 @@ class Function(Doc):
                     s = linked_annotation.join(s.rsplit(annotation, 1))  # "rreplace" once
 
             params.append(s)
+
+        if pos_only:
+            params.append("/")
 
         return params
 

--- a/pdoc/test/__init__.py
+++ b/pdoc/test/__init__.py
@@ -802,6 +802,15 @@ class ApiTest(unittest.TestCase):
         self.assertEqual(pdoc.Function('get_sample', mod, get_sample).return_annotation(),
                          'Tuple[int,\xa0float]')
 
+    @unittest.skipIf(sys.version_info < (3, 8), "positional-only arguments unsupported in < py3.8")
+    def test_test_Function_params_python38_specific(self):
+        mod = pdoc.Module(pdoc)
+        func = pdoc.Function('f', mod, eval("lambda a, /, b: None"))
+        self.assertEqual(func.params(), ['a', '/', 'b'])
+
+        func = pdoc.Function('f', mod, eval("lambda a, /: None"))
+        self.assertEqual(func.params(), ['a', '/'])
+
     def test_Function_return_annotation(self):
         import typing
 


### PR DESCRIPTION
Fixes #183 