### PR TITLE
reStrucutured text :param: :return: support

### DIFF
--- a/pdoc/html_helpers.py
+++ b/pdoc/html_helpers.py
@@ -129,6 +129,7 @@ class _ToMarkdown:
     — they are all perfect!) an insta-preview tool such as RegEx101.com
     will come in handy.
     """
+
     @staticmethod
     def _deflist(name, type, desc):
         """

--- a/pdoc/html_helpers.py
+++ b/pdoc/html_helpers.py
@@ -129,7 +129,6 @@ class _ToMarkdown:
     — they are all perfect!) an insta-preview tool such as RegEx101.com
     will come in handy.
     """
-
     @staticmethod
     def _deflist(name, type, desc):
         """

--- a/pdoc/html_helpers.py
+++ b/pdoc/html_helpers.py
@@ -237,6 +237,9 @@ class _ToMarkdown:
         Convert `text` in Google-style docstring format to Markdown
         to be further converted later.
         """
+        text = text.replace(":param", "\nArgs:\n   ", 1)
+        text = text.replace(":param",  "   ")
+        text = text.replace(":return:", "\n\nReturns:")
         def googledoc_sections(match):
             section, body = match.groups('')
             if not body:

--- a/pdoc/html_helpers.py
+++ b/pdoc/html_helpers.py
@@ -241,6 +241,7 @@ class _ToMarkdown:
         text = text.replace(":param", "\nArgs:\n   ", 1)
         text = text.replace(":param",  "   ")
         text = text.replace(":return:", "\n\nReturns:")
+
         def googledoc_sections(match):
             section, body = match.groups('')
             if not body:


### PR DESCRIPTION
Dear @kernc, maintainers,

For issue #110 I have implemented quite a dirty hack that adds the reSt `:param x:` and `:return:` directives replacing them with the Google-style docstring.

This does not break any of the tests, but I have not implemented a specific test for it, while it works in my case.

Fixes #110 
