### PR TITLE
Use non-breaking hyphen in ‑> arrow (follow up #51)

### DIFF
--- a/pdoc/templates/html.mako
+++ b/pdoc/templates/html.mako
@@ -107,7 +107,7 @@
     <dt id="${f.refname}"><code class="name flex">
         <%
             params = ', '.join(f.params(annotate=show_type_annotations, link=link))
-            return_type = get_annotation(f.return_annotation, ''\N{non-breaking hyphen}>'')
+            return_type = get_annotation(f.return_annotation, '\N{non-breaking hyphen}>')
         %>
         <span>${f.funcdef()} ${ident(f.name)}</span>(<span>${params})${return_type}</span>
     </code></dt>

--- a/pdoc/templates/html.mako
+++ b/pdoc/templates/html.mako
@@ -107,7 +107,7 @@
     <dt id="${f.refname}"><code class="name flex">
         <%
             params = ', '.join(f.params(annotate=show_type_annotations, link=link))
-            return_type = get_annotation(f.return_annotation, '->')
+            return_type = get_annotation(f.return_annotation, '‑>')
         %>
         <span>${f.funcdef()} ${ident(f.name)}</span>(<span>${params})${return_type}</span>
     </code></dt>

--- a/pdoc/templates/html.mako
+++ b/pdoc/templates/html.mako
@@ -107,7 +107,7 @@
     <dt id="${f.refname}"><code class="name flex">
         <%
             params = ', '.join(f.params(annotate=show_type_annotations, link=link))
-            return_type = get_annotation(f.return_annotation, '‑>')
+            return_type = get_annotation(f.return_annotation, ''\N{non-breaking hyphen}>'')
         %>
         <span>${f.funcdef()} ${ident(f.name)}</span>(<span>${params})${return_type}</span>
     </code></dt>

--- a/pdoc/templates/pdf.mako
+++ b/pdoc/templates/pdf.mako
@@ -34,7 +34,7 @@ ${('#' * level) + ' ' + string + id}
     <%
         returns = show_type_annotations and f.return_annotation() or ''
         if returns:
-            returns = ' ‑> ' + returns
+            returns = ' '\N{non-breaking hyphen}>' ' + returns
     %>
 > `${f.funcdef()} ${f.name}(${', '.join(f.params(annotate=show_type_annotations))})${returns}`
 </%def>

--- a/pdoc/templates/pdf.mako
+++ b/pdoc/templates/pdf.mako
@@ -34,7 +34,7 @@ ${('#' * level) + ' ' + string + id}
     <%
         returns = show_type_annotations and f.return_annotation() or ''
         if returns:
-            returns = ' -> ' + returns
+            returns = ' ‑> ' + returns
     %>
 > `${f.funcdef()} ${f.name}(${', '.join(f.params(annotate=show_type_annotations))})${returns}`
 </%def>

--- a/pdoc/templates/pdf.mako
+++ b/pdoc/templates/pdf.mako
@@ -34,7 +34,7 @@ ${('#' * level) + ' ' + string + id}
     <%
         returns = show_type_annotations and f.return_annotation() or ''
         if returns:
-            returns = ' '\N{non-breaking hyphen}>' ' + returns
+            returns = ' \N{non-breaking hyphen}> ' + returns
     %>
 > `${f.funcdef()} ${f.name}(${', '.join(f.params(annotate=show_type_annotations))})${returns}`
 </%def>

--- a/pdoc/templates/text.mako
+++ b/pdoc/templates/text.mako
@@ -15,7 +15,7 @@
     <%
         returns = show_type_annotations and func.return_annotation() or ''
         if returns:
-            returns = ' '\N{non-breaking hyphen}>' ' + returns
+            returns = ' \N{non-breaking hyphen}> ' + returns
     %>
 `${func.name}(${", ".join(func.params(annotate=show_type_annotations))})${returns}`
 ${func.docstring | deflist}

--- a/pdoc/templates/text.mako
+++ b/pdoc/templates/text.mako
@@ -15,7 +15,7 @@
     <%
         returns = show_type_annotations and func.return_annotation() or ''
         if returns:
-            returns = ' -> ' + returns
+            returns = ' ‑> ' + returns
     %>
 `${func.name}(${", ".join(func.params(annotate=show_type_annotations))})${returns}`
 ${func.docstring | deflist}

--- a/pdoc/templates/text.mako
+++ b/pdoc/templates/text.mako
@@ -15,7 +15,7 @@
     <%
         returns = show_type_annotations and func.return_annotation() or ''
         if returns:
-            returns = ' ‑> ' + returns
+            returns = ' '\N{non-breaking hyphen}>' ' + returns
     %>
 `${func.name}(${", ".join(func.params(annotate=show_type_annotations))})${returns}`
 ${func.docstring | deflist}


### PR DESCRIPTION
The ASCII sequence `->` which has replaced the Unicode arrow character in #51 may break when it's near the last column:

![image](https://user-images.githubusercontent.com/3048819/82427650-aa810280-9a89-11ea-8583-777493d3b2a1.png)

Unicode provides a non-breaking hyphen (U+2011) which should look the same, but without this disadvantage: `‑>`.