### PR TITLE
Normalize `.. include::` path on Windos

### DIFF
--- a/pdoc/html_helpers.py
+++ b/pdoc/html_helpers.py
@@ -331,7 +331,7 @@ class _ToMarkdown:
         start_after = options.get('start-after')
         end_before = options.get('end-before')
 
-        with open(os.path.join(os.path.dirname(module.obj.__file__), path),
+        with open(os.path.normpath(os.path.join(os.path.dirname(module.obj.__file__), path)),
                   encoding='utf-8') as f:
             text = ''.join(list(f)[start_line:end_line])
 

--- a/pdoc/test/example_pkg/_reST_include/test.py
+++ b/pdoc/test/example_pkg/_reST_include/test.py
@@ -5,7 +5,7 @@
         :end-line: 2
 ```
 
-.. include:: _include_me.py
+.. include:: foo/../_include_me.py
     :start-after: =
     :end-before: 4
 """


### PR DESCRIPTION
This is fixing issue when you have an `include` on an `__init__.py` file which is trying to find a file on a parent directory in Windows.

With the previous implementation, it was mixing `\\` (from Windows) with `../` from include and also the final path was not the correct one.