### PR TITLE
ENH: Roll custom `getmembers()` that works with Enum and typed-only namespaces

### DIFF
--- a/pdoc/__init__.py
+++ b/pdoc/__init__.py
@@ -23,7 +23,7 @@ from functools import lru_cache, reduce, partial
 from itertools import tee, groupby
 from types import ModuleType
 from typing import (
-    cast, Callable, Dict, Generator, Iterable, List, Mapping, Optional, Set, Tuple,
+    cast, Any, Callable, Dict, Generator, Iterable, List, Mapping, Optional, Set, Tuple,
     Type, TypeVar, Union,
 )
 from warnings import warn
@@ -882,7 +882,7 @@ class Module(Doc):
         return url + _URL_MODULE_SUFFIX
 
 
-def _getmembers_all(obj: type) -> List[Tuple[str, object]]:
+def _getmembers_all(obj: type) -> List[Tuple[str, Any]]:
     mro = obj.__mro__[:-1]  # Skip object
     names = set(dir(obj))
     # Add keys from bases

--- a/pdoc/__init__.py
+++ b/pdoc/__init__.py
@@ -883,6 +883,7 @@ class Module(Doc):
 
 
 def _getmembers_all(obj: type) -> List[Tuple[str, Any]]:
+    # The following code based on inspect.getmembers() @ 5b23f7618d43
     mro = obj.__mro__[:-1]  # Skip object
     names = set(dir(obj))
     # Add keys from bases

--- a/pdoc/test/__init__.py
+++ b/pdoc/test/__init__.py
@@ -991,11 +991,9 @@ class Foo:
         self.assertIsInstance(cls.doc['func'], pdoc.Function)
 
         # GH-210, GH-212
-        class Employee2:
-            """ An employee. """
-            name: str
-
-        cls = pdoc.Class('Employee2', module, Employee2)
+        my_locals = {}
+        exec('class Employee:\n name: str', my_locals)
+        cls = pdoc.Class('Employee', module, my_locals['Employee'])
         self.assertIsInstance(cls.doc['name'], pdoc.Variable)
         self.assertEqual(cls.doc['name'].type_annotation(), 'str')
 

--- a/pdoc/test/__init__.py
+++ b/pdoc/test/__init__.py
@@ -972,6 +972,33 @@ class Foo:
         self.assertEqual(mod.name, 'pdoc')
         self.assertIn('Module', mod.doc)
 
+    @ignore_warnings
+    @unittest.skipIf(sys.version_info < (3, 6), 'variable type annotation unsupported in <Py3.6')
+    def test_class_members(self):
+        module = pdoc.Module(EXAMPLE_MODULE)
+
+        # GH-200
+        from enum import Enum
+
+        class Tag(Enum):
+            Char = 1
+
+            def func(self):
+                return self
+
+        cls = pdoc.Class('Tag', module, Tag)
+        self.assertIsInstance(cls.doc['Char'], pdoc.Variable)
+        self.assertIsInstance(cls.doc['func'], pdoc.Function)
+
+        # GH-210, GH-212
+        class Employee2:
+            """ An employee. """
+            name: str
+
+        cls = pdoc.Class('Employee2', module, Employee2)
+        self.assertIsInstance(cls.doc['name'], pdoc.Variable)
+        self.assertEqual(cls.doc['name'].type_annotation(), 'str')
+
 
 class HtmlHelpersTest(unittest.TestCase):
     """


### PR DESCRIPTION
Fixes https://github.com/pdoc3/pdoc/issues/200
Fixes https://github.com/pdoc3/pdoc/issues/210
Fixes https://github.com/pdoc3/pdoc/issues/212

Thanks @mbhall88.