### PR TITLE
Use __init__ instead of __new__ to document class params

### DIFF
--- a/pdoc/__init__.py
+++ b/pdoc/__init__.py
@@ -1242,7 +1242,15 @@ class Function(Doc):
     @staticmethod
     def _params(doc_obj, annotate=False, link=None, module=None):
         try:
-            signature = inspect.signature(doc_obj.obj)
+            # We want __init__ to actually be implemented somewhere in the
+            # MRO to still satisfy https://github.com/pdoc3/pdoc/issues/124
+            if (
+                inspect.isclass(doc_obj.obj)
+                and doc_obj.obj.__init__ is not object.__init__
+            ):
+                signature = inspect.signature(doc_obj.obj.__init__)
+            else:
+                signature = inspect.signature(doc_obj.obj)
         except ValueError:
             signature = Function._signature_from_string(doc_obj)
             if not signature:

--- a/pdoc/__init__.py
+++ b/pdoc/__init__.py
@@ -1248,7 +1248,10 @@ class Function(Doc):
                 inspect.isclass(doc_obj.obj)
                 and doc_obj.obj.__init__ is not object.__init__
             ):
-                signature = inspect.signature(doc_obj.obj.__init__)
+                # Remove the first argument (self) from __init__ signature
+                init_sig = inspect.signature(doc_obj.obj.__init__)
+                init_params = list(init_sig.parameters.values())
+                signature = init_sig.replace(parameters=init_params[1:])
             else:
                 signature = inspect.signature(doc_obj.obj)
         except ValueError:

--- a/pdoc/test/__init__.py
+++ b/pdoc/test/__init__.py
@@ -944,6 +944,11 @@ class Foo:
 
         self.assertEqual(pdoc.Class('G', mod, G).params(), ['self', 'a', 'b', 'c=100'])
 
+        class G2(typing.Generic[T]):
+            pass
+
+        self.assertEqual(pdoc.Class('G2', mod, G2).params(), ['*args', '**kwds'])
+
     def test_url(self):
         mod = pdoc.Module(EXAMPLE_MODULE)
         pdoc.link_inheritance()

--- a/pdoc/test/__init__.py
+++ b/pdoc/test/__init__.py
@@ -364,7 +364,7 @@ class CliTest(unittest.TestCase):
         self.assertIn('pdoc3.github.io', out)
         self.assertIn('pandoc', err)
 
-        pdoc_Doc_params = str(inspect.signature(pdoc.Doc.__init__))
+        pdoc_Doc_params = str(inspect.signature(pdoc.Doc.__init__)).replace('self, ', '')
         self.assertIn(pdoc_Doc_params.replace(' ', ''),
                       out.replace('>', '').replace('\n', '').replace(' ', ''))
 
@@ -928,7 +928,7 @@ class Foo:
                 pass
 
         mod = pdoc.Module(pdoc)
-        self.assertEqual(pdoc.Class('C', mod, C).params(), ['self', 'x'])
+        self.assertEqual(pdoc.Class('C', mod, C).params(), ['x'])
         with patch.dict(mod.obj.__pdoc__, {'C.__init__': False}):
             self.assertEqual(pdoc.Class('C', mod, C).params(), [])
 
@@ -942,7 +942,7 @@ class Foo:
             def __init__(self, a, b, c=100):
                 pass
 
-        self.assertEqual(pdoc.Class('G', mod, G).params(), ['self', 'a', 'b', 'c=100'])
+        self.assertEqual(pdoc.Class('G', mod, G).params(), ['a', 'b', 'c=100'])
 
         class G2(typing.Generic[T]):
             pass


### PR DESCRIPTION
Fixes #191 

Using `inspect.signature` to get the signature of a class will return the signature of `__new__`, if implemented. However, I don't think there are necessarily use cases for this when `__init__` is actually implemented. For example:

```python
class A(Generic[T]):
   """doc"""
   def __init__(self, a, b):
        """bar"""
        pass
```

This will show the correct documentation but the signature will be, of course, `*args, **kwargs`. The small proposed change ensures that the signature of `__init__` is used if it is implemented (i.e. `obj.__init__ is not object.__init__`. 

EDIT:
Added an additional test case for when `__new__` is implemented but `__init__` isn't.