### PR TITLE
Set `typing.TYPE_CHECKING` to `True` when importing module

### DIFF
--- a/pdoc/__init__.py
+++ b/pdoc/__init__.py
@@ -211,10 +211,13 @@ def import_module(module: Union[str, ModuleType],
     if isinstance(module, str):
         with _module_path(module) as module_path:
             try:
+                typing.TYPE_CHECKING = True
                 module = importlib.import_module(module_path)
             except Exception as e:
                 raise ImportError('Error importing {!r}: {}: {}'
                                   .format(module, e.__class__.__name__, e))
+            finally:
+                typing.TYPE_CHECKING = False
 
     assert inspect.ismodule(module)
     # If this is pdoc itself, return without reloading. Otherwise later

--- a/pdoc/test/example_pkg/__init__.py
+++ b/pdoc/test/example_pkg/__init__.py
@@ -1,7 +1,13 @@
 """Module docstring"""
+from __future__ import annotations
+
 from collections import namedtuple
 import subprocess
 import os
+import typing
+
+if typing.TYPE_CHECKING:
+    import datetime
 
 CONST = 'const'
 """CONST docstring"""
@@ -14,6 +20,18 @@ foreign_var = subprocess.CalledProcessError(0, '')
 """foreign var docstring"""
 
 __pdoc__ = {}
+
+
+class Foo:
+    def bar(self, a: datetime.datetime) -> None:
+        """Resolves typehints when using `typing.TYPE_CHECKING`"""
+
+    baz: typing.Optional[datetime.datetime] = None
+    """Resolves typehints when using `typing.TYPE_CHECKING`"""
+
+
+def bar(self, a: datetime.datetime) -> None:
+    """Resolves typehints when using `typing.TYPE_CHECKING`"""
 
 
 def foo(env=os.environ):


### PR DESCRIPTION
Closes #245