### PR TITLE
feat: Avoid trying to extract PEP-224 docstrings from builtins

### DIFF
--- a/pdoc/__init__.py
+++ b/pdoc/__init__.py
@@ -242,8 +242,10 @@ def _pep224_docstrings(doc_obj: Union['Module', 'Class'], *,
     The second dict contains instance variables and is non-empty only in case
     `doc_obj` is a `pdoc.Class` which has `__init__` method.
     """
-    # No variables in namespace packages
-    if isinstance(doc_obj, Module) and doc_obj.is_namespace:
+    is_builtins = type(doc_obj.obj).__module__ == 'builtins'
+
+    # No variables in builtins or namespace packages.
+    if is_builtins or (isinstance(doc_obj, Module) and doc_obj.is_namespace):
         return {}, {}
 
     vars = {}  # type: Dict[str, str]

--- a/pdoc/__init__.py
+++ b/pdoc/__init__.py
@@ -242,9 +242,7 @@ def _pep224_docstrings(doc_obj: Union['Module', 'Class'], *,
     The second dict contains instance variables and is non-empty only in case
     `doc_obj` is a `pdoc.Class` which has `__init__` method.
     """
-    is_builtins = type(doc_obj.obj).__module__ == 'builtins'
-
-    # No variables in namespace packages.
+    # No variables in namespace packages
     if isinstance(doc_obj, Module) and doc_obj.is_namespace:
         return {}, {}
 
@@ -260,11 +258,10 @@ def _pep224_docstrings(doc_obj: Union['Module', 'Class'], *,
             _ = inspect.findsource(doc_obj.obj)
             tree = ast.parse(doc_obj.source)  # type: ignore
         except (OSError, TypeError, SyntaxError) as exc:
-            # That's OK if a builtin does not a docstring. Maybe the
-            # source isn't accessible. Do not emit a warning for that.
-            if not is_builtins:
+            # Don't emit a warning for builtins that don't have source available
+            is_builtin = getattr(doc_obj.obj, '__module__', None) == 'builtins'
+            if not is_builtin:
                 warn("Couldn't read PEP-224 variable docstrings from {!r}: {}".format(doc_obj, exc))
-
             return {}, {}
 
         if isinstance(doc_obj, Class):


### PR DESCRIPTION
If a module or a class is a builtin (e.g. from an extension), the
`_pep224_docstrings` function will generate a lot of warnings. This
patch skips the extraction of the PEP-224 docstrings for builtins
modules or classes.