### PR TITLE
documentation on how docstrings of `__init__()` methods are processed

### DIFF
--- a/pdoc/documentation.md
+++ b/pdoc/documentation.md
@@ -108,7 +108,7 @@ In the default HTML template, such inherited docstrings are greyed out.
 
 Note that the docstring of a class's `__init__()` method is directly
 appended to the class's docstring when generating the documentation
-with pdoc. A valid approach is to not document the `__init__()` method
+with `pdoc`. A valid approach is to not document the `__init__()` method
 at all and directly add, for example, a `Parameters` section to the
 docstring of the class that describes the arguments of the __init__()
 method.  That way all necessary information on how to instantiate the

--- a/pdoc/documentation.md
+++ b/pdoc/documentation.md
@@ -103,8 +103,8 @@ it will automatically attach the docstring for `A.test` to
 In the default HTML template, such inherited docstrings are greyed out.
 
 
-### Docstrings of __init__() methods
-[docstrings init methods]: #docstrings-init-methods
+### Docstring of `__init__()` method
+[docstring init method]: #docstring-init-method
 
 Note that the docstring of a class's `__init__()` method is directly
 appended to the class's docstring when generating the documentation

--- a/pdoc/documentation.md
+++ b/pdoc/documentation.md
@@ -104,13 +104,13 @@ In the default HTML template, such inherited docstrings are greyed out.
 
 
 ### Docstring of `__init__()` method
-[docstring init method]: #docstring-init-method
+[init docstring]: #docstring-of-__init__-method
 
 Note that the docstring of a class's `__init__()` method is directly
 appended to the class's docstring when generating the documentation
 with `pdoc`. A valid approach is to not document the `__init__()` method
 at all and directly add, for example, a `Parameters` section to the
-docstring of the class that describes the arguments of the __init__()
+docstring of the class that describes the arguments of the `__init__()`
 method.  That way all necessary information on how to instantiate the
 class is directly provided by the docstring of the class.
 

--- a/pdoc/documentation.md
+++ b/pdoc/documentation.md
@@ -103,6 +103,18 @@ it will automatically attach the docstring for `A.test` to
 In the default HTML template, such inherited docstrings are greyed out.
 
 
+### Docstrings of __init__() methods
+[docstrings init methods]: #docstrings-init-methods
+
+Note that the docstring of a class's `__init__()` method is directly
+appended to the class's docstring when generating the documentation
+with pdoc. A valid approach is to not document the `__init__()` method
+at all and directly add, for example, a `Parameters` section to the
+docstring of the class that describes the arguments of the __init__()
+method.  That way all necessary information on how to instantiate the
+class is directly provided by the docstring of the class.
+
+
 ### Docstrings for variables
 [variable docstrings]: #docstrings-for-variables
 


### PR DESCRIPTION
see issue #255 