### PR TITLE
ENH: Add support for reST-style docstrings

### DIFF
--- a/pdoc/html_helpers.py
+++ b/pdoc/html_helpers.py
@@ -12,6 +12,11 @@ from functools import partial, lru_cache
 from typing import Callable, Match
 from warnings import warn
 import xml.etree.ElementTree as etree
+import docutils.nodes
+import docutils.core
+import collections
+from typing import Union
+
 
 import markdown
 from markdown.inlinepatterns import InlineProcessor
@@ -266,69 +271,154 @@ class _ToMarkdown:
         return text
 
     @staticmethod
+    def _reST_string_to_html(text: str) -> str:
+        """Convert reST text to html using docutils
+
+        :param text: The text to convert
+        :returns: The generated html
+        """
+        html = docutils.core.publish_parts(text, writer_name='html')['html_body']
+
+        # Remove the document tag and return
+        return html[23:-8]
+
+    @staticmethod
+    def _reST_node_to_html(node: docutils.nodes.Node,
+                           doctree: docutils.nodes.document) -> str:
+        """Not all nodes in the doctree provide their reST source or at least the
+        starting line in the reST source. This method simply copies the document
+        tree and removes all but the node to then publish it.
+
+        :node: The node to publish. Must be a child of `doctree` itself
+        :doctree: The document having `node` as a child node
+        :return: The generated html for this node
+        """
+        # Remove all but the given node from the doctree
+        children_copy = doctree.children
+        doctree.children = [doctree.children[doctree.index(node)]]
+
+        # Generate the html for this node/doctree
+        html = docutils.core.publish_from_doctree(doctree, writer_name='html5').decode('utf-8')
+
+        # Restore the doctree
+        doctree.children = children_copy
+
+        # Return only the relevant part of the html
+        return re.search(r"<div class=\"document\">(.+)<\/div>", html, re.DOTALL).group(1).strip()
+
+    @staticmethod
+    def _reST_field_list_to_markdown(field_list: Union[docutils.nodes.field_list,
+                                                       docutils.nodes.docinfo]) -> str:
+        """Processes a docutils field list and converts it to markdown.
+        Args, Vars, Returns, and Raises sections are predefined, other sections
+        will be created corresponding to their field names.
+
+        :param field_list: A docutils field list to convert. Can also be a docinfo
+            in case, e.g., only :returns: is specified without any summary text
+        :returns: The generated Markdown. However, it is not pure Markdown, as
+            the field descriptions have been processed with `docutils.process_string` - they
+            therefore are already converted to HTML
+        """
+        # Sort the field list so that types come last  - in case someone defines first the type then
+        # the parameter
+        field_list.children.sort(key=lambda field: 'type' in field[0].rawsource.split()[0])
+
+        # Predefined sections for the generated markdown
+        tags_to_section_map = {
+            ('param', 'parameter', 'arg', 'argument', 'key', 'keyword'): 'Args',
+            ('var', 'ivar', 'cvar'): 'Vars',
+            ('return', 'returns'): 'Returns',
+            ('raise', 'raises'): 'Raises'
+        }
+        sections = collections.OrderedDict([('Args', []), ('Vars', []),
+                                            ('Returns', []), ('Raises', [])])
+
+        # Process the fields
+        for field in field_list:
+            field_name = field.children[0]
+            field_body = field.children[1]
+
+            # Split the field name into its components
+            split = field_name.rawsource.split()
+            tag = split[0]
+            type_ = split[1] if len(split) == 3 else None
+            name = split[2] if len(split) == 3 else split[1] if len(split) == 2 else None
+
+            # Fill the sections
+            try:
+                section = [section for tags, section in tags_to_section_map.items()
+                           if tag in tags][0]
+            except IndexError:  # Field is not corresponding to a predefined section like Args
+                section = None
+
+            if section is not None:
+                sections[section].append({'name': name,
+                                          'type': type_,
+                                          'body': _ToMarkdown._reST_string_to_html(
+                                              field_body.rawsource)})
+            elif tag == 'rtype':
+                # Set the return type. Assumes that at most one :return: has been specified
+                try:
+                    sections['Returns'][0]['type'] = field_body.rawsource
+                except IndexError:  # Only return type is specified
+                    sections['Returns'].append({'name': None,
+                                                'type': field_body.rawsource.strip(),
+                                                'body': ''})
+            elif 'type' in tag:
+                section = 'Vars' if tag == 'vartype' else 'Args'
+                try:
+                    param_or_var = [x for x in sections[section] if x['name'] == name][0]
+                    param_or_var['type'] = field_body.rawsource.strip()
+                except IndexError:  # Only parameter (or variable) type is specified
+                    sections[section].append({'name': name,
+                                              'type': field_body.rawsource.strip(),
+                                              'body': ''})
+            elif tag == 'meta':
+                pass  # Meta fields should be excluded from the final output
+            else:
+                # Generate sections for tags not covered yet
+                section = sections.get(tag, [])
+                section.append({'name': name,
+                                'type': type_,
+                                'body': _ToMarkdown._reST_string_to_html(field_body.rawsource)})
+                sections[tag] = section
+
+        # Generate the markdown for this field list
+        markdown = []
+        for section, fields in sections.items():
+            if len(fields) > 0:  # Skip empty sections
+                markdown.append(f'{section}:\n-----=')
+
+                for field in fields:
+                    field['body'] = field['body'].replace('\n', '\n  ')  # For proper indentation
+                    if field['name'] or field['type']:
+                        markdown.append(
+                            _ToMarkdown._deflist(*_ToMarkdown._fix_indent(field['name'],
+                                                                          field['type'],
+                                                                          field['body'])))
+                    else:  # For fields with no name or type (e.g. Returns without type spec)
+                        text = _ToMarkdown._fix_indent(
+                            field['name'], field['type'], field['body'])[2]
+                        markdown.append(f':   {text}')
+
+        return '\n'.join(markdown)
+
+    @staticmethod
     def reST(text: str) -> str:
         """
-        Convert `text` in reST-style docstring format to Markdown
-        to be further converted later.
+        Convert `text` in reST-style docstring format to Markdown - with embedded html
+        for paragraphs and field descriptions - to be further converted later.
         """
-        def reST_sections(match) -> str:
-            # E.g. for ":param arg1: Text" tag is "param", name is "arg1", and body is "Text"
-            tag, name, body = match.groups('')
-            body = textwrap.dedent(body)
+        doctree = docutils.core.publish_doctree(text)
 
-            type_ = None
-            nonlocal active_section
-            active_section_changed = False
-
-            if tag in ['type', 'rtype']:
-                return ''
-            elif tag in ('param', 'parameter', 'arg', 'argument', 'key', 'keyword'):
-                type_ = parameter_types.get(name, None)
-
-                if active_section != 'Args':
-                    active_section = 'Args'
-                    active_section_changed = True
-            elif tag in ('return', 'returns'):
-                if len(return_types) > 0:
-                    type_ = return_types.pop()
-
-                if active_section != 'Returns':
-                    active_section = 'Returns'
-                    active_section_changed = True
-            elif tag in ('raise', 'raises'):
-                if active_section != 'Raises':
-                    active_section = 'Raises'
-                    active_section_changed = True
-
-            if name or type_:
-                text = _ToMarkdown._deflist(*_ToMarkdown._fix_indent(name, type_, body))
+        generated_markdown = []
+        for section in doctree:
+            if section.tagname in ('field_list', 'docinfo'):
+                generated_markdown.append(_ToMarkdown._reST_field_list_to_markdown(section))
             else:
-                _, _, body = _ToMarkdown._fix_indent(name, type_, body)
-                text = f':   {body}'
+                generated_markdown.append(_ToMarkdown._reST_node_to_html(section, doctree))
 
-            if active_section_changed:
-                text = f'\n{active_section}:\n-----=\n{text}'
-            else:
-                text = f'\n{text}'
-
-            return text
-
-        regex = re.compile(r'^:(\S+)(?:\s(\S+?))?:((?:\n?(?: .*|$))+)', re.MULTILINE)
-
-        # Get all parameter and return types beforehand, to then use them when substituting
-        # the sections
-        parameter_types = {}
-        return_types = []
-        for tag, name, body in regex.findall(text):
-            if tag == 'type':
-                parameter_types[name] = body.strip()
-            elif tag == 'rtype':
-                return_types.append(body.strip())
-
-        active_section = None  # Keep track of the currently active section (e.g. Args, Returns)
-        text = regex.sub(reST_sections, text)
-
-        return text
+        return '\n'.join(generated_markdown)
 
     @staticmethod
     def _admonition(match, module=None, limit_types=None):
@@ -509,41 +599,41 @@ def to_markdown(text: str, *,
 
         # Infer docformat if it hasn't been specified
         if docformat == '':
-            reST_tags = ['param', 'arg', 'type', 'raise', 'except', 'return', 'rtype']
+            reST_tags = ['param ', 'arg ', 'type ', 'raise ', 'except ', 'return', 'rtype']
             reST_regex = fr'^:(?:{"|".join(reST_tags)}).*?:'
             found_reST_tags = re.findall(reST_regex, text, re.MULTILINE)
 
-            # Assume reST-style docstring if any of the above specified tags is present at the beginning of a line.
-            # Could make this more robust, e.g., by checking against the amount of found google or numpy tags
-            if len(found_reST_tags) > 0:
-                docformat = 'reST '
-            else:
-                docformat = 'numpy,google '
+            # Assume reST-style docstring if any of the above specified tags is present at the
+            # beginning of a line.  Could make this more robust, e.g., by checking against the
+            # amount of found google or numpy tags
+            docformat = 'restructuredtext ' if len(found_reST_tags) > 0 else 'numpy,google '
 
         docformat, *_ = docformat.lower().split()
 
-    if not (set(docformat.split(',')) & {'', 'numpy', 'google', 'rest'}):
+    if not (set(docformat.split(',')) & {'', 'numpy', 'google', 'restructuredtext'}):
         warn('__docformat__ value {!r} in module {!r} not supported. '
-             'Supported values are: numpy, google, reST.'.format(docformat, module))
+             'Supported values are: numpy, google, restructuredtext.'.format(docformat, module))
         docformat = 'numpy,google'
 
     with _fenced_code_blocks_hidden(text) as result:
         text = result[0]
 
-        text = _ToMarkdown.admonitions(text, module)
+        if 'restructuredtext' not in docformat:  # Will be handled by docutils
+            text = _ToMarkdown.admonitions(text, module)
 
         if 'google' in docformat:
             text = _ToMarkdown.google(text)
 
         text = _ToMarkdown.doctests(text)
-        text = _ToMarkdown.raw_urls(text)
+        if 'restructuredtext' not in docformat:  # Will be handled by docutils
+            text = _ToMarkdown.raw_urls(text)
 
         # If doing both, do numpy after google, otherwise google-style's
         # headings are incorrectly interpreted as numpy params
         if 'numpy' in docformat:
             text = _ToMarkdown.numpy(text)
 
-        if 'rest' in docformat:
+        if 'restructuredtext' in docformat:
             text = _ToMarkdown.reST(text)
 
         if module and link:

--- a/pdoc/html_helpers.py
+++ b/pdoc/html_helpers.py
@@ -15,7 +15,7 @@ import xml.etree.ElementTree as etree
 import docutils.nodes
 import docutils.core
 import collections
-from typing import *
+from typing import Union
 
 
 import markdown
@@ -284,7 +284,7 @@ class _ToMarkdown:
 
     @staticmethod
     def _reST_node_to_html(node: docutils.nodes.Node,
-                          doctree: docutils.nodes.document) -> str:
+                           doctree: docutils.nodes.document) -> str:
         """Not all nodes in the doctree provide their reST source or at least the
         starting line in the reST source. This method simply copies the document
         tree and removes all but the node to then publish it.
@@ -346,7 +346,8 @@ class _ToMarkdown:
 
             # Fill the sections
             try:
-                section = [section for tags, section in tags_to_section_map.items() if tag in tags][0]
+                section = [section for tags, section in tags_to_section_map.items()
+                           if tag in tags][0]
             except IndexError:  # Field is not corresponding to a predefined section like Args
                 section = None
 
@@ -389,13 +390,15 @@ class _ToMarkdown:
                 markdown.append(f'{section}:\n-----=')
 
                 for field in fields:
-                    field['body'] = field['body'].replace('\n', '\n  ')  # Allow for proper indentation
+                    field['body'] = field['body'].replace('\n', '\n  ')  # For proper indentation
                     if field['name'] or field['type']:
-                        markdown.append(_ToMarkdown._deflist(*_ToMarkdown._fix_indent(field['name'],
-                                                                                      field['type'],
-                                                                                      field['body'])))
-                    else:  # For fields with no name or type (e.g. Returns without type specification)
-                        text = _ToMarkdown._fix_indent(field['name'], field['type'], field['body'])[2]
+                        markdown.append(
+                            _ToMarkdown._deflist(*_ToMarkdown._fix_indent(field['name'],
+                                                                          field['type'],
+                                                                          field['body'])))
+                    else:  # For fields with no name or type (e.g. Returns without type spec)
+                        text = _ToMarkdown._fix_indent(
+                            field['name'], field['type'], field['body'])[2]
                         markdown.append(f':   {text}')
 
         return '\n'.join(markdown)
@@ -600,8 +603,9 @@ def to_markdown(text: str, *,
             reST_regex = fr'^:(?:{"|".join(reST_tags)}).*?:'
             found_reST_tags = re.findall(reST_regex, text, re.MULTILINE)
 
-            # Assume reST-style docstring if any of the above specified tags is present at the beginning of a line.
-            # Could make this more robust, e.g., by checking against the amount of found google or numpy tags
+            # Assume reST-style docstring if any of the above specified tags is present at the
+            # beginning of a line.  Could make this more robust, e.g., by checking against the
+            # amount of found google or numpy tags
             docformat = 'restructuredtext ' if len(found_reST_tags) > 0 else 'numpy,google '
 
         docformat, *_ = docformat.lower().split()

--- a/pdoc/test/__init__.py
+++ b/pdoc/test/__init__.py
@@ -1403,6 +1403,36 @@ that are relevant to the interface.</p>
         html = to_html(text, module=self._module, link=self._link)
         self.assertEqual(html, expected)
 
+    def test_reST(self):
+        expected = '''<p>Summary line.</p>
+<h2 id="args">Args:</h2>
+<dl>
+<dt><strong><code>arg1</code></strong> :&ensp;<code>int</code></dt>
+<dd>Text1</dd>
+<dt><strong><code>arg2</code></strong> :&ensp;<code>Optional[List[Tuple[str]]]</code></dt>
+<dd>Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed
+ diam nonumy eirmod tempor invidunt</dd>
+<dt><strong><code>arg_arg_3</code></strong> :&ensp;<code>Dict[int, Dict[str, Any]]</code></dt>
+<dd>Y:=H^T<em>X!@#$%^&amp;&amp;</em>()_[]{}';'::</dd>
+</dl>
+<h2 id="returns">Returns:</h2>
+<dl>
+<dt><code>bool</code></dt>
+<dd>True. Or False. Depends</dd>
+<dd>Now with more "s"</dd>
+</dl>
+<h2 id="raises">Raises:</h2>
+<dl>
+<dt><strong><code>Exception</code></strong></dt>
+<dd>Raised occasionally</dd>
+<dt><strong><code>ZeroDivisionError</code></strong></dt>
+<dd>You know why and when</dd>
+</dl>'''
+        text = inspect.getdoc(self._docmodule.reST)
+        html = to_html(text, module=self._module, link=self._link)
+
+        self.assertEqual(html, expected)
+
     def test_doctests(self):
         expected = '''<p>Need an intro paragrapgh.</p>
 <pre><code>&gt;&gt;&gt; Then code is indented one level

--- a/pdoc/test/__init__.py
+++ b/pdoc/test/__init__.py
@@ -233,8 +233,14 @@ class CliTest(unittest.TestCase):
             )
 
     def test_docformat(self):
+        def test_docformat(self):
+            with self.assertWarns(UserWarning) as cm, \
+                    run_html(EXAMPLE_MODULE, config='docformat="epytext"'):
+                self._basic_html_assertions()
+            self.assertIn('numpy', cm.warning.args[0])
+
         with self.assertWarns(UserWarning) as cm,\
-                run_html(EXAMPLE_MODULE, config='docformat="restructuredtext"'):
+                run_html(EXAMPLE_MODULE, config='docformat="epytext"'):
             self._basic_html_assertions()
         self.assertIn('numpy', cm.warning.args[0])
 
@@ -1403,36 +1409,6 @@ that are relevant to the interface.</p>
         html = to_html(text, module=self._module, link=self._link)
         self.assertEqual(html, expected)
 
-    def test_reST(self):
-        expected = '''<p>Summary line.</p>
-<h2 id="args">Args:</h2>
-<dl>
-<dt><strong><code>arg1</code></strong> :&ensp;<code>int</code></dt>
-<dd>Text1</dd>
-<dt><strong><code>arg2</code></strong> :&ensp;<code>Optional[List[Tuple[str]]]</code></dt>
-<dd>Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed
- diam nonumy eirmod tempor invidunt</dd>
-<dt><strong><code>arg_arg_3</code></strong> :&ensp;<code>Dict[int, Dict[str, Any]]</code></dt>
-<dd>Y:=H^T<em>X!@#$%^&amp;&amp;</em>()_[]{}';'::</dd>
-</dl>
-<h2 id="returns">Returns:</h2>
-<dl>
-<dt><code>bool</code></dt>
-<dd>True. Or False. Depends</dd>
-<dd>Now with more "s"</dd>
-</dl>
-<h2 id="raises">Raises:</h2>
-<dl>
-<dt><strong><code>Exception</code></strong></dt>
-<dd>Raised occasionally</dd>
-<dt><strong><code>ZeroDivisionError</code></strong></dt>
-<dd>You know why and when</dd>
-</dl>'''
-        text = inspect.getdoc(self._docmodule.reST)
-        html = to_html(text, module=self._module, link=self._link)
-
-        self.assertEqual(html, expected)
-
     def test_doctests(self):
         expected = '''<p>Need an intro paragrapgh.</p>
 <pre><code>&gt;&gt;&gt; Then code is indented one level
@@ -1463,6 +1439,121 @@ Exception: something went wrong
 </code></pre>'''
         text = inspect.getdoc(self._docmodule.doctests)
         html = to_html(text, module=self._module, link=self._link)
+        self.assertEqual(html, expected)
+
+    def test_reST(self):
+        expected = '''<p>Summary line.</p>
+<p>Some stuff to test like <a class="reference external" href="http://www.python.org">http://www.python.org</a> or <a class="reference external" href="http://www.python.org">link_text</a>.
+Also <em>italic</em> and <strong>bold</strong>. And lists:</p>
+<ul class="simple">
+<li><p>1</p></li>
+<li><p>2</p></li>
+</ul>
+<ol class="arabic simple">
+<li><p>Item</p></li>
+<li><p>Item</p></li>
+</ol>
+<h2 id="args">Args:</h2>
+<dl>
+<dt><strong><code>arg1</code></strong> :&ensp;<code>int</code></dt>
+<dd><p>Text1</p></dd>
+<dt><strong><code>arg2</code></strong> :&ensp;<code>Optional[List[Tuple[str]]]</code></dt>
+<dd><p>Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed
+diam nonumy eirmod tempor invidunt</p></dd>
+<dt><strong><code>arg_arg_3</code></strong> :&ensp;<code>Dict[int, Dict[str, Any]]</code></dt>
+<dd><p>Y:=H^T<em>X!&#64;#$%^&amp;&amp;</em>()_[]{}';'::{[( :param just_in_case:</p></dd>
+<dt><strong><code>another_parameter</code></strong> :&ensp;<code>str</code></dt>
+<dd>&nbsp;</dd>
+</dl>
+<h2 id="vars">Vars:</h2>
+<dl>
+<dt><strong><code>x</code></strong></dt>
+<dd><p>Description of variable x</p></dd>
+<dt><strong><code>y</code></strong> :&ensp;<code>List[bool]</code></dt>
+<dd><p>Description of variable y</p></dd>
+<dt><strong><code>z</code></strong> :&ensp;<code>str</code></dt>
+<dd><p>Descriptions can also be placed in a new line.</p>
+<p>And span multiple lines.</p></dd>
+</dl>
+<h2 id="returns">Returns:</h2>
+<dl>
+<dt><code>bool</code></dt>
+<dd><p>True. Or False. Depends</p></dd>
+</dl>
+<p>A paragraph to split the field list into two.</p>
+<h2 id="returns_1">Returns:</h2>
+<dl>
+<dd>
+<dl>
+<dt><p>Now with more &quot;s&quot;</p></dt>
+<dt>Raises:</dt>
+<dt>-----=</dt>
+<dt><strong><code>Exception</code></strong></dt>
+<dd><p>Raised occasionally</p></dd>
+</dl>
+</dd>
+<dt><strong><code>ZeroDivisionError</code></strong></dt>
+<dd><p>You know why and when</p></dd>
+</dl>
+<p>Some more tests below:</p>
+<h2 id="args_1">Args:</h2>
+<dl>
+<dt><strong><code>z</code></strong> :&ensp;<code>str</code></dt>
+<dd>&nbsp;</dd>
+</dl>
+<h2 id="vars_1">Vars:</h2>
+<dl>
+<dt><strong><code>x</code></strong> :&ensp;<code>int</code></dt>
+<dd>&nbsp;</dd>
+</dl>
+<h2 id="returns_2">Returns:</h2>
+<dl>
+<dt><code>int</code></dt>
+<dd>&nbsp;</dd>
+</dl>
+<p>And now for some other stuff</p>
+<div class="admonition admonition-todo">
+<p class="admonition-title">TODO</p>
+<p>Create something.</p>
+</div>
+<div class="admonition admonition-example">
+<p class="admonition-title">Example</p>
+<p>Image shows something.</p>
+<img alt="https://www.debian.org/logos/openlogo-nd-100.png" src="https://www.debian.org/logos/openlogo-nd-100.png" />
+<div class="admonition note">
+<p class="admonition-title">Note</p>
+<p>Can only nest admonitions two levels.</p>
+</div>
+</div>
+<p><img alt="https://www.debian.org/logos/openlogo-nd-100.png" src="https://www.debian.org/logos/openlogo-nd-100.png" /></p>
+<p>Now you know.</p>
+<div class="admonition warning">
+<p class="admonition-title">Warning</p>
+<p>Some warning
+lines.</p>
+</div>
+<ul>
+<li><p>Describe some func in a list
+across multiple lines:</p>
+<blockquote>
+<div class="admonition admonition-deprecated-since-3-1">
+<p class="admonition-title">Deprecated since 3.1</p>
+<p>Use <cite>spam</cite> instead.</p>
+</div>
+<div class="admonition admonition-added-in-version-2-5">
+<p class="admonition-title">Added in version 2.5</p>
+<p>The <em>spam</em> parameter.</p>
+</div>
+</blockquote>
+</li>
+</ul>
+<div class="admonition caution">
+<p class="admonition-title">Caution!</p>
+<p>Don't touch this!</p>
+</div>'''  # noqa: 501
+        text = inspect.getdoc(self._docmodule.reST)
+        html = to_html(text, module=self._module, link=self._link)
+
         self.assertEqual(html, expected)
 
     def test_reST_directives(self):
@@ -1506,6 +1597,7 @@ lines.</p>
 </div>'''
         text = inspect.getdoc(self._docmodule.reST_directives)
         html = to_html(text, module=self._module, link=self._link)
+
         self.assertEqual(html, expected)
 
     def test_reST_include(self):

--- a/pdoc/test/__init__.py
+++ b/pdoc/test/__init__.py
@@ -234,7 +234,7 @@ class CliTest(unittest.TestCase):
 
     def test_docformat(self):
         with self.assertWarns(UserWarning) as cm,\
-                run_html(EXAMPLE_MODULE, config='docformat="restructuredtext"'):
+                run_html(EXAMPLE_MODULE, config='docformat="epytext"'):
             self._basic_html_assertions()
         self.assertIn('numpy', cm.warning.args[0])
 
@@ -1403,36 +1403,6 @@ that are relevant to the interface.</p>
         html = to_html(text, module=self._module, link=self._link)
         self.assertEqual(html, expected)
 
-    def test_reST(self):
-        expected = '''<p>Summary line.</p>
-<h2 id="args">Args:</h2>
-<dl>
-<dt><strong><code>arg1</code></strong> :&ensp;<code>int</code></dt>
-<dd>Text1</dd>
-<dt><strong><code>arg2</code></strong> :&ensp;<code>Optional[List[Tuple[str]]]</code></dt>
-<dd>Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed
- diam nonumy eirmod tempor invidunt</dd>
-<dt><strong><code>arg_arg_3</code></strong> :&ensp;<code>Dict[int, Dict[str, Any]]</code></dt>
-<dd>Y:=H^T<em>X!@#$%^&amp;&amp;</em>()_[]{}';'::</dd>
-</dl>
-<h2 id="returns">Returns:</h2>
-<dl>
-<dt><code>bool</code></dt>
-<dd>True. Or False. Depends</dd>
-<dd>Now with more "s"</dd>
-</dl>
-<h2 id="raises">Raises:</h2>
-<dl>
-<dt><strong><code>Exception</code></strong></dt>
-<dd>Raised occasionally</dd>
-<dt><strong><code>ZeroDivisionError</code></strong></dt>
-<dd>You know why and when</dd>
-</dl>'''
-        text = inspect.getdoc(self._docmodule.reST)
-        html = to_html(text, module=self._module, link=self._link)
-
-        self.assertEqual(html, expected)
-
     def test_doctests(self):
         expected = '''<p>Need an intro paragrapgh.</p>
 <pre><code>&gt;&gt;&gt; Then code is indented one level
@@ -1463,6 +1433,121 @@ Exception: something went wrong
 </code></pre>'''
         text = inspect.getdoc(self._docmodule.doctests)
         html = to_html(text, module=self._module, link=self._link)
+        self.assertEqual(html, expected)
+
+    def test_reST(self):
+        expected = '''<p>Summary line.</p>
+<p>Some stuff to test like <a class="reference external" href="http://www.python.org">http://www.python.org</a> or <a class="reference external" href="http://www.python.org">link_text</a>.
+Also <em>italic</em> and <strong>bold</strong>. And lists:</p>
+<ul class="simple">
+<li><p>1</p></li>
+<li><p>2</p></li>
+</ul>
+<ol class="arabic simple">
+<li><p>Item</p></li>
+<li><p>Item</p></li>
+</ol>
+<h2 id="args">Args:</h2>
+<dl>
+<dt><strong><code>arg1</code></strong> :&ensp;<code>int</code></dt>
+<dd><p>Text1</p></dd>
+<dt><strong><code>arg2</code></strong> :&ensp;<code>Optional[List[Tuple[str]]]</code></dt>
+<dd><p>Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed
+diam nonumy eirmod tempor invidunt</p></dd>
+<dt><strong><code>arg_arg_3</code></strong> :&ensp;<code>Dict[int, Dict[str, Any]]</code></dt>
+<dd><p>Y:=H^T<em>X!&#64;#$%^&amp;&amp;</em>()_[]{}';'::{[( :param just_in_case:</p></dd>
+<dt><strong><code>another_parameter</code></strong> :&ensp;<code>str</code></dt>
+<dd>&nbsp;</dd>
+</dl>
+<h2 id="vars">Vars:</h2>
+<dl>
+<dt><strong><code>x</code></strong></dt>
+<dd><p>Description of variable x</p></dd>
+<dt><strong><code>y</code></strong> :&ensp;<code>List[bool]</code></dt>
+<dd><p>Description of variable y</p></dd>
+<dt><strong><code>z</code></strong> :&ensp;<code>str</code></dt>
+<dd><p>Descriptions can also be placed in a new line.</p>
+<p>And span multiple lines.</p></dd>
+</dl>
+<h2 id="returns">Returns:</h2>
+<dl>
+<dt><code>bool</code></dt>
+<dd><p>True. Or False. Depends</p></dd>
+</dl>
+<p>A paragraph to split the field list into two.</p>
+<h2 id="returns_1">Returns:</h2>
+<dl>
+<dd>
+<dl>
+<dt><p>Now with more &quot;s&quot;</p></dt>
+<dt>Raises:</dt>
+<dt>-----=</dt>
+<dt><strong><code>Exception</code></strong></dt>
+<dd><p>Raised occasionally</p></dd>
+</dl>
+</dd>
+<dt><strong><code>ZeroDivisionError</code></strong></dt>
+<dd><p>You know why and when</p></dd>
+</dl>
+<p>Some more tests below:</p>
+<h2 id="args_1">Args:</h2>
+<dl>
+<dt><strong><code>z</code></strong> :&ensp;<code>str</code></dt>
+<dd>&nbsp;</dd>
+</dl>
+<h2 id="vars_1">Vars:</h2>
+<dl>
+<dt><strong><code>x</code></strong> :&ensp;<code>int</code></dt>
+<dd>&nbsp;</dd>
+</dl>
+<h2 id="returns_2">Returns:</h2>
+<dl>
+<dt><code>int</code></dt>
+<dd>&nbsp;</dd>
+</dl>
+<p>And now for some other stuff</p>
+<div class="admonition admonition-todo">
+<p class="admonition-title">TODO</p>
+<p>Create something.</p>
+</div>
+<div class="admonition admonition-example">
+<p class="admonition-title">Example</p>
+<p>Image shows something.</p>
+<img alt="https://www.debian.org/logos/openlogo-nd-100.png" src="https://www.debian.org/logos/openlogo-nd-100.png" />
+<div class="admonition note">
+<p class="admonition-title">Note</p>
+<p>Can only nest admonitions two levels.</p>
+</div>
+</div>
+<p><img alt="https://www.debian.org/logos/openlogo-nd-100.png" src="https://www.debian.org/logos/openlogo-nd-100.png" /></p>
+<p>Now you know.</p>
+<div class="admonition warning">
+<p class="admonition-title">Warning</p>
+<p>Some warning
+lines.</p>
+</div>
+<ul>
+<li><p>Describe some func in a list
+across multiple lines:</p>
+<blockquote>
+<div class="admonition admonition-deprecated-since-3-1">
+<p class="admonition-title">Deprecated since 3.1</p>
+<p>Use <cite>spam</cite> instead.</p>
+</div>
+<div class="admonition admonition-added-in-version-2-5">
+<p class="admonition-title">Added in version 2.5</p>
+<p>The <em>spam</em> parameter.</p>
+</div>
+</blockquote>
+</li>
+</ul>
+<div class="admonition caution">
+<p class="admonition-title">Caution!</p>
+<p>Don't touch this!</p>
+</div>'''
+        text = inspect.getdoc(self._docmodule.reST)
+        html = to_html(text, module=self._module, link=self._link)
+
         self.assertEqual(html, expected)
 
     def test_reST_directives(self):
@@ -1506,6 +1591,7 @@ lines.</p>
 </div>'''
         text = inspect.getdoc(self._docmodule.reST_directives)
         html = to_html(text, module=self._module, link=self._link)
+
         self.assertEqual(html, expected)
 
     def test_reST_include(self):

--- a/pdoc/test/__init__.py
+++ b/pdoc/test/__init__.py
@@ -233,6 +233,12 @@ class CliTest(unittest.TestCase):
             )
 
     def test_docformat(self):
+        def test_docformat(self):
+            with self.assertWarns(UserWarning) as cm, \
+                    run_html(EXAMPLE_MODULE, config='docformat="epytext"'):
+                self._basic_html_assertions()
+            self.assertIn('numpy', cm.warning.args[0])
+
         with self.assertWarns(UserWarning) as cm,\
                 run_html(EXAMPLE_MODULE, config='docformat="epytext"'):
             self._basic_html_assertions()
@@ -1544,7 +1550,7 @@ across multiple lines:</p>
 <div class="admonition caution">
 <p class="admonition-title">Caution!</p>
 <p>Don't touch this!</p>
-</div>'''
+</div>'''  # noqa: 501
         text = inspect.getdoc(self._docmodule.reST)
         html = to_html(text, module=self._module, link=self._link)
 

--- a/pdoc/test/__init__.py
+++ b/pdoc/test/__init__.py
@@ -233,12 +233,6 @@ class CliTest(unittest.TestCase):
             )
 
     def test_docformat(self):
-        def test_docformat(self):
-            with self.assertWarns(UserWarning) as cm, \
-                    run_html(EXAMPLE_MODULE, config='docformat="epytext"'):
-                self._basic_html_assertions()
-            self.assertIn('numpy', cm.warning.args[0])
-
         with self.assertWarns(UserWarning) as cm,\
                 run_html(EXAMPLE_MODULE, config='docformat="epytext"'):
             self._basic_html_assertions()

--- a/pdoc/test/example_pkg/__init__.py
+++ b/pdoc/test/example_pkg/__init__.py
@@ -298,6 +298,25 @@ class Docformats:
             Exception: something went wrong
         """
 
+    def reST(self):
+        """
+        Summary line.
+
+        :param arg1: Text1
+        :parameter arg2: Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed
+            diam nonumy eirmod tempor invidunt
+        :arg arg_arg_3: Y:=H^T*X!@#$%^&&*()_[]{}';'::
+        :type arg1: int
+        :type arg2: Optional[List[Tuple[str]]]
+        :type arg_arg_3: Dict[int, Dict[str, Any]]
+        :return: True. Or False. Depends
+        :rtype: bool
+
+        :returns: Now with more "s"
+        :raise Exception: Raised occasionally
+        :raises ZeroDivisionError: You know why and when
+        """
+
     def reST_directives(self):
         """
         .. todo::
@@ -343,6 +362,9 @@ google = Docformats.google
 
 
 doctests = Docformats.doctests
+
+
+reST = Docformats.reST
 
 
 reST_directives = Docformats.reST_directives

--- a/pdoc/test/example_pkg/__init__.py
+++ b/pdoc/test/example_pkg/__init__.py
@@ -302,19 +302,83 @@ class Docformats:
         """
         Summary line.
 
+        Some stuff to test like http://www.python.org or `link_text <http://www.python.org>`_.
+        Also *italic* and **bold**. And lists:
+
+        * 1
+        * 2
+
+        #. Item
+        #. Item
+
         :param arg1: Text1
         :parameter arg2: Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed
             diam nonumy eirmod tempor invidunt
-        :arg arg_arg_3: Y:=H^T*X!@#$%^&&*()_[]{}';'::
+        :arg arg_arg_3: Y:=H^T*X!@#$%^&&*()_[]{}';'::{[( :param just_in_case:
+        :key str another_parameter:
         :type arg1: int
         :type arg2: Optional[List[Tuple[str]]]
         :type arg_arg_3: Dict[int, Dict[str, Any]]
+        :var x: Description of variable x
+        :ivar y: Description of variable y
+        :cvar str z:
+            Descriptions can also be placed in a new line.
+
+            And span multiple lines.
+        :vartype y: List[bool]
         :return: True. Or False. Depends
         :rtype: bool
+        :meta: This should not be displayed in the generated output document
+
+        A paragraph to split the field list into two.
 
         :returns: Now with more "s"
         :raise Exception: Raised occasionally
         :raises ZeroDivisionError: You know why and when
+
+        Some more tests below:
+
+        :rtype: int
+        :vartype x: int
+        :type z: str
+
+        And now for some other stuff
+
+        .. admonition:: TODO
+
+           Create something.
+
+        .. admonition:: Example
+
+           Image shows something.
+
+           .. image:: https://www.debian.org/logos/openlogo-nd-100.png
+
+           .. note::
+              Can only nest admonitions two levels.
+
+        .. image:: https://www.debian.org/logos/openlogo-nd-100.png
+
+        Now you know.
+
+        .. warning::
+
+            Some warning
+            lines.
+
+        * Describe some func in a list
+          across multiple lines:
+
+            .. admonition:: Deprecated since 3.1
+
+                Use `spam` instead.
+
+            .. admonition:: Added in version 2.5
+
+                The *spam* parameter.
+
+        .. caution::
+            Don't touch this!
         """
 
     def reST_directives(self):

--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,7 @@ if __name__ == '__main__':
         provides=["pdoc"],
         obsoletes=["pdoc"],
         install_requires=[
+            "docutils >= 0.16",
             "mako",
             "markdown >= 3.0",
         ],


### PR DESCRIPTION
Hi kernc and all contributors,

Addressing issues #110 and #273, I added support for reST-style docstrings, following your suggestions in #198.

Additionally, in case the docformat is not explicitly specified, it will be distinguished between reST-style and Numpy-/Google-style in `html_helpers.to_markdown`.

Fixes #110 
Fixes #273 
Closes #198 