### PR TITLE
Add support for variable doc-comments starting with '#:'

### DIFF
--- a/pdoc/__init__.py
+++ b/pdoc/__init__.py
@@ -347,17 +347,17 @@ def _pep224_docstrings(doc_obj: Union['Module', 'Class'], *,
             comment_lines = []
             for line in reversed(source_lines[:assign_node.lineno - 1]):
                 if get_line_indentation(line) == assignment_line_indentation and \
-                        line.lstrip().startswith('#:'):
-                    comment_lines.append(line.split('#:', 1)[1])
+                        line.lstrip().startswith('#: '):
+                    comment_lines.append(line.split('#: ', 1)[1])
                 else:
                     break
 
             # Since we went 'up' need to reverse lines to be in correct order
             comment_lines = comment_lines[::-1]
 
-            # Finally: check for a '#:' comment at the end of the assignment line itself.
-            if '#:' in assignment_line:
-                comment_lines.append(assignment_line.rsplit('#:', 1)[-1])
+            # Finally: check for a '#: ' comment at the end of the assignment line itself.
+            if '#: ' in assignment_line:
+                comment_lines.append(assignment_line.rsplit('#: ', 1)[-1])
 
             if comment_lines:
                 # Adding 2 spaces to the end of each line to ensure we keep line breaks

--- a/pdoc/__init__.py
+++ b/pdoc/__init__.py
@@ -360,8 +360,7 @@ def _pep224_docstrings(doc_obj: Union['Module', 'Class'], *,
                 comment_lines.append(assignment_line.rsplit('#: ', 1)[-1])
 
             if comment_lines:
-                # Adding 2 spaces to the end of each line to ensure we keep line breaks
-                vars[name] = '\n'.join([c + '  ' for c in comment_lines])
+                vars[name] = '\n'.join(comment_lines)
 
     return vars, instance_vars
 

--- a/pdoc/documentation.md
+++ b/pdoc/documentation.md
@@ -108,10 +108,10 @@ In the default HTML template, such inherited docstrings are greyed out.
 
 Python by itself [doesn't allow docstrings attached to variables][PEP-224].
 However, `pdoc` supports docstrings attached to module (or global)
-variables, class variables, and object instance variables; all in
-the same way as proposed in [PEP-224], with a docstring following the
-variable assignment.
-For example:
+variables, class variables, and object instance variables; all available via
+two different mechanisms: [PEP-224], and '#:' doc-comments.
+
+For example via PEP-224:
 
 [PEP-224]: http://www.python.org/dev/peps/pep-0224
 
@@ -125,6 +125,29 @@ For example:
         def __init__(self):
             self.variable = 3
             """Docstring for instance variable."""
+
+For example via '#:' doc-comments
+
+    #: Docstring for module_variable.
+    module_variable = 1
+
+    class C:
+        #: Docstring for class_variable.
+        class_variable = 2
+
+
+        def __init__(self):
+            #: Docstring for instance variable.
+            self.variable = 3
+
+Note that '#:' doc-comments can be both multi-line and appear on the same line after
+variable declaration.
+
+For example:
+
+    #: This is line 1 of my documentation for module_variable
+    #: This is line 2 of my documentation for module_variable
+    module_variable = 1 #: This is line 3 of my documentation for module_variable
 
 While the resulting variables have no `__doc__` attribute,
 `pdoc` compensates by reading the source code (when available)

--- a/pdoc/documentation.md
+++ b/pdoc/documentation.md
@@ -107,47 +107,26 @@ In the default HTML template, such inherited docstrings are greyed out.
 [variable docstrings]: #docstrings-for-variables
 
 Python by itself [doesn't allow docstrings attached to variables][PEP-224].
-However, `pdoc` supports docstrings attached to module (or global)
-variables, class variables, and object instance variables; all available via
-two different mechanisms: [PEP-224], and '#:' doc-comments.
+However, `pdoc` supports documenting module (or global)
+variables, class variables, and object instance variables via
+two different mechanisms: [PEP-224] and `#:` doc-comments.
 
-For example via PEP-224:
+For example:
 
 [PEP-224]: http://www.python.org/dev/peps/pep-0224
 
     module_variable = 1
-    """Docstring for module_variable."""
+    """PEP 224 docstring for module_variable."""
 
     class C:
-        class_variable = 2
-        """Docstring for class_variable."""
+        #: Documentation comment for class_variable
+        #: spanning over three lines.
+        class_variable = 2  #: Assignment line is included.
 
         def __init__(self):
+            #: Instance variable's doc-comment
             self.variable = 3
-            """Docstring for instance variable."""
-
-For example via '#:' doc-comments
-
-    #: Docstring for module_variable.
-    module_variable = 1
-
-    class C:
-        #: Docstring for class_variable.
-        class_variable = 2
-
-
-        def __init__(self):
-            #: Docstring for instance variable.
-            self.variable = 3
-
-Note that '#:' doc-comments can be both multi-line and appear on the same line after
-variable declaration.
-
-For example:
-
-    #: This is line 1 of my documentation for module_variable
-    #: This is line 2 of my documentation for module_variable
-    module_variable = 1 #: This is line 3 of my documentation for module_variable
+            """But note, PEP 224 docstrings take precedence."""
 
 While the resulting variables have no `__doc__` attribute,
 `pdoc` compensates by reading the source code (when available)

--- a/pdoc/html_helpers.py
+++ b/pdoc/html_helpers.py
@@ -560,6 +560,11 @@ def format_git_link(template: str, dobj: pdoc.Doc):
             commit = _git_head_commit()
         abs_path = inspect.getfile(inspect.unwrap(dobj.obj))
         path = _project_relative_path(abs_path)
+
+        # Urls should always use / instead of \\
+        if os.name == 'nt':
+            path = path.replace('\\', '/')
+
         lines, start_line = inspect.getsourcelines(dobj.obj)
         end_line = start_line + len(lines) - 1
         url = template.format(**locals())

--- a/pdoc/test/__init__.py
+++ b/pdoc/test/__init__.py
@@ -1616,7 +1616,7 @@ cmd `pwd`
         self.assertEqual(html, expected)
 
 
-@unittest.skipIf('win' in sys.platform, "signal.SIGALRM doesn't work on Windows")
+@unittest.skipIf('win' in sys.platform, "signal.SIGALRM doesn't work on Windos")
 class HttpTest(unittest.TestCase):
     """
     Unit tests for the HTTP server functionality.

--- a/pdoc/test/__init__.py
+++ b/pdoc/test/__init__.py
@@ -106,25 +106,25 @@ class CliTest(unittest.TestCase):
     """
     ALL_FILES = [
         'example_pkg',
-        'example_pkg/index.html',
-        'example_pkg/index.m.html',
-        'example_pkg/module.html',
-        'example_pkg/_private',
-        'example_pkg/_private/index.html',
-        'example_pkg/_private/module.html',
-        'example_pkg/subpkg',
-        'example_pkg/subpkg/_private.html',
-        'example_pkg/subpkg/index.html',
-        'example_pkg/subpkg2',
-        'example_pkg/subpkg2/_private.html',
-        'example_pkg/subpkg2/module.html',
-        'example_pkg/subpkg2/index.html',
+         os.path.join('example_pkg', 'index.html'),
+         os.path.join('example_pkg', 'index.m.html'),
+         os.path.join('example_pkg', 'module.html'),
+         os.path.join('example_pkg', '_private'),
+         os.path.join('example_pkg', '_private', 'index.html'),
+         os.path.join('example_pkg', '_private', 'module.html'),
+         os.path.join('example_pkg', 'subpkg'),
+         os.path.join('example_pkg', 'subpkg', '_private.html'),
+         os.path.join('example_pkg', 'subpkg', 'index.html'),
+         os.path.join('example_pkg', 'subpkg2'),
+         os.path.join('example_pkg', 'subpkg2', '_private.html'),
+         os.path.join('example_pkg', 'subpkg2', 'module.html'),
+         os.path.join('example_pkg', 'subpkg2', 'index.html'),
     ]
-    PUBLIC_FILES = [f for f in ALL_FILES if '/_' not in f]
+    PUBLIC_FILES = [f for f in ALL_FILES if (os.path.sep + '_') not in f]
 
-    if os.name == 'nt':
-        ALL_FILES = [i.replace('/', '\\') for i in ALL_FILES]
-        PUBLIC_FILES = [i.replace('/', '\\') for i in PUBLIC_FILES]
+    #if os.name == 'nt':
+    #    ALL_FILES = [i.replace('/', '\\') for i in ALL_FILES]
+    #    PUBLIC_FILES = [i.replace('/', '\\') for i in PUBLIC_FILES]
 
     def setUp(self):
         pdoc.reset()
@@ -190,7 +190,7 @@ class CliTest(unittest.TestCase):
             '.subpkg2': [f for f in self.PUBLIC_FILES
                          if 'subpkg2' in f or f == EXAMPLE_MODULE],
             '._private': [f for f in self.ALL_FILES
-                          if EXAMPLE_MODULE + '/_private' in f or f == EXAMPLE_MODULE],
+                          if EXAMPLE_MODULE + os.path.sep + '_private' in f or f == EXAMPLE_MODULE],
         }
         for package, expected_files in package_files.items():
             with self.subTest(package=package):
@@ -203,7 +203,7 @@ class CliTest(unittest.TestCase):
         filenames_files = {
             ('module.py',): ['module.html'],
             ('module.py', 'subpkg2'): ['module.html', 'subpkg2',
-                                       'subpkg2/index.html', 'subpkg2/module.html'],
+                                       os.path.join('subpkg2', 'index.html'), os.path.join('subpkg2', 'module.html')],
         }
         with chdir(TESTS_BASEDIR):
             for filenames, expected_files in filenames_files.items():
@@ -216,9 +216,9 @@ class CliTest(unittest.TestCase):
 
     def test_html_multiple_files(self):
         with chdir(TESTS_BASEDIR):
-            with run_html(EXAMPLE_MODULE + '/module.py', EXAMPLE_MODULE + '/subpkg2'):
+            with run_html(os.path.join(EXAMPLE_MODULE, 'module.py'), os.path.join(EXAMPLE_MODULE, 'subpkg2')):
                 self._basic_html_assertions(
-                    ['module.html', 'subpkg2', 'subpkg2/index.html', 'subpkg2/module.html'])
+                    ['module.html', 'subpkg2', os.path.join('subpkg2', 'index.html'), os.path.join('subpkg2', 'module.html')])
 
     def test_html_identifier(self):
         for package in ('', '._private'):
@@ -232,7 +232,7 @@ class CliTest(unittest.TestCase):
     def test_html_ref_links(self):
         with run_html(EXAMPLE_MODULE, config='show_source_code=False'):
             self._check_files(
-                file_pattern=EXAMPLE_MODULE + '/index.html',
+                file_pattern=os.path.join(EXAMPLE_MODULE, 'index.html'),
                 include_patterns=[
                     'href="#example_pkg.B">',
                     'href="#example_pkg.A">',

--- a/pdoc/test/__init__.py
+++ b/pdoc/test/__init__.py
@@ -1123,18 +1123,13 @@ class C:
        self.instance_var = 1
 ''')
 
-            module = pdoc.import_module(filename)
-            pdoc_module = pdoc.Module(module)
+            mod = pdoc.Module(pdoc.import_module(filename))
 
-            cls_name_to_docs, instance_name_to_docs = pdoc._pep224_docstrings(pdoc_module)
-            self.assertEqual(cls_name_to_docs, {
-                                                'var2': 'PEP-224 takes precedence',
-                                                'var1': 'Line 1\nLine 2\nLine 3'})
-
-            pdoc_class = pdoc.Class('C', pdoc_module, module.C)
-            cls_name_to_docs, instance_name_to_docs = pdoc._pep224_docstrings(pdoc_class)
-            self.assertEqual(cls_name_to_docs, {'class_var': 'class var'})
-            self.assertEqual(instance_name_to_docs, {'instance_var': 'instance var'})
+            self.assertEqual(mod.doc['var1'].docstring, 'Line 1\nLine 2\nLine 3')
+            self.assertEqual(mod.doc['var2'].docstring, 'PEP-224 takes precedence')
+            self.assertEqual(mod.doc['C'].docstring, '')
+            self.assertEqual(mod.doc['C'].doc['class_var'].docstring, 'class var')
+            self.assertEqual(mod.doc['C'].doc['instance_var'].docstring, 'instance var')
 
 
 class HtmlHelpersTest(unittest.TestCase):


### PR DESCRIPTION
I'd like to write a unit-test for this functionality, though I'm having some trouble running the existing suite: #291 

This basically matches up with sphinx behavior and a similar implementation.

Fixes #289
Resolves https://github.com/pdoc3/pdoc/issues/291