### PR TITLE
When using --http, also reload submodules - fix #264

### DIFF
--- a/pdoc/__init__.py
+++ b/pdoc/__init__.py
@@ -230,6 +230,10 @@ def import_module(module: Union[str, ModuleType],
     # `isinstance(..., pdoc.Doc)` calls won't work correctly.
     if reload and not module.__name__.startswith(__name__):
         module = importlib.reload(module)
+        # We recursively reload all submodules, in case __all_ is used - cf. issue #264
+        for mod_key, mod in list(sys.modules.items()):
+            if mod_key.startswith(module.__name__):
+                importlib.reload(mod)
     return module
 
 

--- a/pdoc/cli.py
+++ b/pdoc/cli.py
@@ -265,7 +265,7 @@ class _WebDoc(BaseHTTPRequestHandler):
         """
         return pdoc.html(self.import_path_from_req_url,
                          reload=True, http_server=True, external_links=True,
-                         skip_errors=args.skip_errors,
+                         skip_errors=self.args.skip_errors,
                          **self.template_config)
 
     def resolve_ext(self, import_path):


### PR DESCRIPTION
Fixes #264 

The fix in `cli.py` was made to avoid this error while pressing `F5` in my browser when using `--http`:

```
Error importing module fpdf:

Traceback (most recent call last):
  File "/home/lucas_cimon/.local/share/virtualenvs/pyfpdf/lib/python3.7/site-packages/pdoc/cli.py", line 234, in do_GET
    out = self.html()
  File "/home/lucas_cimon/.local/share/virtualenvs/pyfpdf/lib/python3.7/site-packages/pdoc/cli.py", line 267, in html
    skip_errors=args.skip_errors,
AttributeError: 'Namespace' object has no attribute 'skip_errors'
```