### PR TITLE
Fix a fatal error preventing documentation generation in some cases

### DIFF
--- a/pdoc/__init__.py
+++ b/pdoc/__init__.py
@@ -683,12 +683,13 @@ class Module(Doc):
             for name in self.obj.__all__:
                 try:
                     obj = getattr(self.obj, name)
-                    if not _is_blacklisted(name, self):
-                        obj = inspect.unwrap(obj)
-                    public_objs.append((name, obj))
                 except AttributeError:
                     warn(f"Module {self.module!r} doesn't contain identifier `{name}` "
                          "exported in `__all__`")
+                else:
+                    if not _is_blacklisted(name, self):
+                        obj = inspect.unwrap(obj)
+                    public_objs.append((name, obj))
         else:
             def is_from_this_module(obj):
                 mod = inspect.getmodule(inspect.unwrap(obj))

--- a/pdoc/__init__.py
+++ b/pdoc/__init__.py
@@ -683,12 +683,12 @@ class Module(Doc):
             for name in self.obj.__all__:
                 try:
                     obj = getattr(self.obj, name)
+                    if not _is_blacklisted(name, self):
+                        obj = inspect.unwrap(obj)
+                    public_objs.append((name, obj))
                 except AttributeError:
                     warn(f"Module {self.module!r} doesn't contain identifier `{name}` "
                          "exported in `__all__`")
-                if not _is_blacklisted(name, self):
-                    obj = inspect.unwrap(obj)
-                public_objs.append((name, obj))
         else:
             def is_from_this_module(obj):
                 mod = inspect.getmodule(inspect.unwrap(obj))


### PR DESCRIPTION
Got a fatal exception on this line, which prevented the generation of the documentation.

The problem is that some variable is initialized in a try bloc but still used out of it afterwards.
If the getattr fails line 682 - which was my problem - then the variable is used without being initialized, which lead to fatal error.