### PR TITLE
Recurse through submodules in extension modules

### DIFF
--- a/pdoc/__init__.py
+++ b/pdoc/__init__.py
@@ -708,6 +708,10 @@ class Module(Doc):
                 self.doc[name] = Function(name, self, obj)
             elif inspect.isclass(obj):
                 self.doc[name] = Class(name, self, obj)
+            elif inspect.ismodule(obj):
+                self.doc[name] = Module(
+                    obj, docfilter=docfilter, supermodule=self,
+                    context=context, skip_errors=skip_errors)
             elif name in var_docstrings:
                 self.doc[name] = Variable(name, self, var_docstrings[name], obj=obj)
 

--- a/pdoc/test/__init__.py
+++ b/pdoc/test/__init__.py
@@ -472,6 +472,35 @@ class ApiTest(unittest.TestCase):
                     self.assertEqual(sorted(m.name for m in m.submodules()),
                                      [EXAMPLE_MODULE + '.' + m for m in submodules])
 
+    @ignore_warnings
+    def test_module_without_path(self):
+        # GH-319: https://github.com/pdoc3/pdoc/issues/319
+        parent_module = ModuleType('parent_module')
+        child_module1 = ModuleType('child_module1')
+        child_module2 = ModuleType('child_module2')
+        grandchild_module = ModuleType('grandchild_module')
+
+        child_module1.grandchild_module = grandchild_module
+        child_module1.__all__ = ['grandchild_module']
+
+        parent_module.child_module1 = child_module1
+        parent_module.child_module2 = child_module2
+        parent_module.__all__ = ['child_module1', 'child_module2']
+
+        assert not hasattr(parent_module, '__path__')
+        assert not hasattr(child_module1, '__path__')
+        assert not hasattr(child_module2, '__path__')
+        assert not hasattr(grandchild_module, '__path__')
+
+        parent_module_pdoc = pdoc.Module(parent_module)
+
+        children_modules_pdoc = sorted(parent_module_pdoc.submodules(), key=lambda m: m.name)
+        self.assertEqual(
+            [m.name for m in children_modules_pdoc], ['child_module1', 'child_module2'])
+        self.assertEqual(
+            [m.name for m in children_modules_pdoc[0].submodules()], ['grandchild_module'])
+        self.assertEqual(children_modules_pdoc[1].submodules(), [])
+
     def test_Module_find_class(self):
         class A:
             pass


### PR DESCRIPTION
Fixes https://github.com/pdoc3/pdoc/issues/319

The original method of finding submodules by recursing through the
directory structure didn't work with extension modules (aka native "C"
extensions) because there is no directory structure to recurse through.
This commit adds code to recurse through submodules by inspecting
`obj.__all__`, i.e., using the same mechanism that is already used for
finding variables, functions, and classes.

This is a minimalistic first sketch of a solution. It works on a native
extension that I tried it on but it introduces some duplication since
there are now two strategies to search for submodules. For a native
module, the first strategy (searching the directory structure) will fail
but the second (new) strategy (using `obj.__all__`) will work. For
regular modules, both strategies will likely work and so the second
strategy will just overwrite the results from the first strategy with
identical objects. This should technically work but it seems
unnecessary. I just don't feel confident enough to remove the first
strategy without further guidance.