### PR TITLE
Make `unittest.mock.Mock` not appear callable

### DIFF
--- a/pdoc/__init__.py
+++ b/pdoc/__init__.py
@@ -26,6 +26,7 @@ from typing import (  # noqa: F401
     cast, Any, Callable, Dict, Generator, Iterable, List, Mapping, NewType,
     Optional, Set, Tuple, Type, TypeVar, Union,
 )
+from unittest.mock import Mock
 from warnings import warn
 
 from mako.lookup import TemplateLookup
@@ -410,7 +411,7 @@ def _is_public(ident_name):
 
 
 def _is_function(obj):
-    return inspect.isroutine(obj) and callable(obj)
+    return inspect.isroutine(obj) and callable(obj) and not isinstance(obj, Mock)  # Mock: GH-350
 
 
 def _is_descriptor(obj):

--- a/pdoc/test/__init__.py
+++ b/pdoc/test/__init__.py
@@ -22,7 +22,8 @@ from random import randint
 from tempfile import TemporaryDirectory
 from time import sleep
 from types import ModuleType
-from unittest.mock import patch
+from unittest import expectedFailure
+from unittest.mock import Mock, patch
 from urllib.error import HTTPError
 from urllib.request import Request, urlopen
 
@@ -350,6 +351,8 @@ class CliTest(unittest.TestCase):
             'B.p docstring',
             'C',
             'B.overridden docstring',
+            'function_mock',
+            'coroutine_mock',
         ]
         exclude_patterns = [
             '_private',
@@ -1156,6 +1159,11 @@ class C:
             self.assertEqual(mod.doc['C'].docstring, '')
             self.assertEqual(mod.doc['C'].doc['class_var'].docstring, 'class var')
             self.assertEqual(mod.doc['C'].doc['instance_var'].docstring, 'instance var')
+
+    @expectedFailure
+    def test_mock_signature_error(self):
+        # GH-350 -- throws `TypeError: 'Mock' object is not subscriptable`:
+        self.assertIsInstance(inspect.signature(Mock(spec=lambda x: x)), inspect.Signature)
 
 
 class HtmlHelpersTest(unittest.TestCase):

--- a/pdoc/test/example_pkg/__init__.py
+++ b/pdoc/test/example_pkg/__init__.py
@@ -2,6 +2,7 @@
 from collections import namedtuple
 import subprocess
 import os
+from unittest.mock import AsyncMock, Mock
 
 CONST = 'const'
 """CONST docstring"""
@@ -363,3 +364,19 @@ def latex_math():
 
 class Location(namedtuple('Location', 'lat lon')):
     """Geo-location, GPS position."""
+
+
+def _func_spec(value: int) -> bool:
+    ...
+
+async def _coro_spec(value: int) -> bool:
+    ...
+
+
+class HasMockAttributes:
+    """
+    Test class containing instances of `unittest.mock.Mock`.
+    """
+
+    function_mock = Mock(spec=_func_spec)
+    coroutine_mock = AsyncMock(spec=_coro_spec)


### PR DESCRIPTION
Fixes #350.