### PR TITLE
BUG: Fix crash on `NotImplementedError`

### DIFF
--- a/pdoc/__init__.py
+++ b/pdoc/__init__.py
@@ -987,7 +987,7 @@ def _getmembers_all(obj: type) -> List[Tuple[str, Any]]:
     for name in names:
         try:
             value = getattr(obj, name)
-        except AttributeError:
+        except (AttributeError, NotImplementedError):
             for base in mro:
                 if name in base.__dict__:
                     value = base.__dict__[name]


### PR DESCRIPTION
Closes #353 

It's a simple fix. Didn't seem to affect the unit tests run. Lmk if this is ok. 😄 