### PR TITLE
Leave trailing line break in reST directives

### DIFF
--- a/pdoc/html_helpers.py
+++ b/pdoc/html_helpers.py
@@ -326,7 +326,7 @@ class _ToMarkdown:
         See: https://python-markdown.github.io/extensions/admonition/
         """
         substitute = partial(re.compile(r'^(?P<indent> *)\.\. ?(\w+)::(?: *(.*))?'
-                                        r'((?:\n(?:(?P=indent) +.*| *$))*[^\n|\r|\r\n])*',
+                                        r'((?:\n(?:(?P=indent) +.*| *$))*[^\r\n])*',
                                         re.MULTILINE).sub,
                              partial(_ToMarkdown._admonition, module=module,
                                      limit_types=limit_types))

--- a/pdoc/html_helpers.py
+++ b/pdoc/html_helpers.py
@@ -98,11 +98,6 @@ def _fenced_code_blocks_hidden(text):
     def hide(text):
         def replace(match):
             orig = match.group()
-
-            # Remove a trailing blank line before the closing ```, which was
-            # added if the code block came in via `.. include::` directive.
-            orig = orig.replace("\n\n```", "\n```")
-
             new = f'@{hash(orig)}@'
             hidden[new] = orig
             return new
@@ -282,17 +277,10 @@ class _ToMarkdown:
 
         if type == 'include' and module:
             try:
-                included_file = _ToMarkdown._include_file(
-                    indent, value, _ToMarkdown._directive_opts(text), module
-                )
+                return _ToMarkdown._include_file(indent, value,
+                                                 _ToMarkdown._directive_opts(text), module)
             except Exception as e:
                 raise RuntimeError(f'`.. include:: {value}` error in module {module.name!r}: {e}')
-
-            # Any trailing whitespace in the included file will have been
-            # trimmed out in the above. To avoid the included file from merging
-            # into the rest of the docstring, manually add a linebreak here.
-            # Ref issue 384 - https://github.com/pdoc3/pdoc/issues/384
-            return f"{included_file}\n"
         if type in ('image', 'figure'):
             alt_text = text.translate(str.maketrans({
                 '\n': ' ',

--- a/pdoc/html_helpers.py
+++ b/pdoc/html_helpers.py
@@ -275,6 +275,9 @@ class _ToMarkdown:
         if limit_types and type not in limit_types:
             return match.group(0)
 
+        if text is None:
+            text = ""
+
         if type == 'include' and module:
             try:
                 return _ToMarkdown._include_file(indent, value,
@@ -323,7 +326,8 @@ class _ToMarkdown:
         See: https://python-markdown.github.io/extensions/admonition/
         """
         substitute = partial(re.compile(r'^(?P<indent> *)\.\. ?(\w+)::(?: *(.*))?'
-                                        r'((?:\n(?:(?P=indent) +.*| *$))*)', re.MULTILINE).sub,
+                                        r'((?:\n(?:(?P=indent) +.*| *$))*[^\n|\r|\r\n])*',
+                                        re.MULTILINE).sub,
                              partial(_ToMarkdown._admonition, module=module,
                                      limit_types=limit_types))
         # Apply twice for nested (e.g. image inside warning)

--- a/pdoc/html_helpers.py
+++ b/pdoc/html_helpers.py
@@ -99,8 +99,8 @@ def _fenced_code_blocks_hidden(text):
         def replace(match):
             orig = match.group()
 
-            # Remove a trailing blank line before the closing ```, which might
-            # have been added while processing `.. include::` directives.
+            # Remove a trailing blank line before the closing ```, which was
+            # added if the code block came in via `.. include::` directive.
             orig = orig.replace("\n\n```", "\n```")
 
             new = f'@{hash(orig)}@'

--- a/pdoc/test/__init__.py
+++ b/pdoc/test/__init__.py
@@ -1568,7 +1568,22 @@ lines.</p>
 <p>1
 x = 2
 x = 3
-x =</p>'''
+x =</p>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Value</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Hello</td>
+<td>World</td>
+</tr>
+</tbody>
+</table>
+<p>Remaining.</p>'''
         mod = pdoc.Module(pdoc.import_module(
             os.path.join(TESTS_BASEDIR, EXAMPLE_MODULE, '_reST_include', 'test.py')))
         html = to_html(mod.docstring, module=mod)

--- a/pdoc/test/example_pkg/_reST_include/table.md
+++ b/pdoc/test/example_pkg/_reST_include/table.md
@@ -1,0 +1,3 @@
+| Name  | Value  |
+| ----- | -----  |
+| Hello | World  |

--- a/pdoc/test/example_pkg/_reST_include/test.py
+++ b/pdoc/test/example_pkg/_reST_include/test.py
@@ -8,4 +8,8 @@
 .. include:: foo/../_include_me.py
     :start-after: =
     :end-before: 4
+
+.. include:: table.md
+
+Remaining.
 """


### PR DESCRIPTION
Closes #384.

Feels a little clunky adding a trailing line break when processing reST directives, to then have to remove it again for reST directives in code blocks, but I couldn't see any other way. Figured I'd submit a PR anyway for feedback and go from there.