### PR TITLE
[WIP] Include static files in config and to sidebar, #115

### DIFF
--- a/pdoc/templates/config.mako
+++ b/pdoc/templates/config.mako
@@ -61,4 +61,9 @@
     # Note: in Python docstrings, either all backslashes need to be escaped (\\)
     # or you need to use raw r-strings.
     latex_math = False
+
+    # If 'static_content' is not empty, each Mardown document will be included
+    # by its key value.
+    # static_content = {'tutorial': 'docs/tutorial.md', 'gallery': 'docs/gallery.md'}
+    static_content = {}
 %>

--- a/pdoc/templates/html.mako
+++ b/pdoc/templates/html.mako
@@ -301,6 +301,13 @@
 
     <h1>Index</h1>
     ${extract_toc(module.docstring) if extract_module_toc_into_sidebar else ''}
+    % if len(static_content):
+    <ul id="static">
+    % for name, filename in static_content.items():
+      <li><h3><a href="${filename}">${name}</a></h3>
+    % endfor
+    </ul>
+    % endif
     <ul id="index">
     % if supermodule:
     <li><h3>Super-module</h3>


### PR DESCRIPTION
I would like to add the possibility of including files in the table of contents. As a first step we will focus only on including markdown files. In a next PR this should be extend to support `.ipynb` and `.html`. My idea is to add a dictionary in the `pdoc/templates/config.mako` where the user can specify the name of the toc as key and the value as the path of the markdown document.

@kernc I am new to `mako` and struggling with some basic tasks. My concept requires to create html files for each included Markdown file. If I got it correctly, the html/md files are generated by 
https://github.com/pdoc3/pdoc/blob/2cce30a9b55eeeddc1ed826c8a2ada53777c3eea/pdoc/cli.py#L572-L582
So I guess one needs to include these static files in the `modules` variable. My problem is that the `config.mako` is not parsed by the `cli.py`. Can you point me to an ansatz on how to circumvent this issue?

Thank you so much for your help and this great project 