### PR TITLE
Replaced distutils.sysconfig.get_python_lib with sysconfig.get_path

### DIFF
--- a/pdoc/cli.py
+++ b/pdoc/cli.py
@@ -487,8 +487,8 @@ def main(_args=None):
         pass  # pdoc was not invoked while in a virtual environment
     else:
         from glob import glob
-        from distutils.sysconfig import get_python_lib
-        libdir = get_python_lib(prefix=venv_dir)
+        from sysconfig import get_path
+        libdir = get_path(prefix=venv_dir)
         sys.path.append(libdir)
         # Resolve egg-links from `setup.py develop` or `pip install -e`
         # XXX: Welcome a more canonical approach

--- a/pdoc/html_helpers.py
+++ b/pdoc/html_helpers.py
@@ -622,9 +622,9 @@ def _project_relative_path(absolute_path):
     Assumes the project's path is either the current working directory or
     Python library installation.
     """
-    from distutils.sysconfig import get_python_lib
+    from sysconfig import get_path
     for prefix_path in (_git_project_root() or os.getcwd(),
-                        get_python_lib()):
+                        get_path()):
         common_path = os.path.commonpath([prefix_path, absolute_path])
         if os.path.samefile(common_path, prefix_path):
             # absolute_path is a descendant of prefix_path


### PR DESCRIPTION
Fixes https://github.com/pdoc3/pdoc/issues/392

As `distutils.sysconfig` is now deprecated.