### PR TITLE
Skip `__editable__` paths during `iter_modules`

### DIFF
--- a/pdoc/__init__.py
+++ b/pdoc/__init__.py
@@ -727,6 +727,8 @@ class Module(Doc):
                 """
                 from os.path import isdir, join
                 for pth in paths:
+                    if pth.startswith("__editable__"):
+                        continue
                     for file in os.listdir(pth):
                         if file.startswith(('.', '__pycache__', '__init__.py')):
                             continue

--- a/pdoc/__init__.py
+++ b/pdoc/__init__.py
@@ -727,7 +727,8 @@ class Module(Doc):
                 """
                 from os.path import isdir, join
                 for pth in paths:
-                    if pth.startswith("__editable__"):
+                    if pth.startswith("__editable__."):
+                        # See https://github.com/pypa/pip/issues/11380
                         continue
                     for file in os.listdir(pth):
                         if file.startswith(('.', '__pycache__', '__init__.py')):


### PR DESCRIPTION
Document generation seems to be broken for `namespace` packages after recent changes to how `__editable__` install work.
