### PR TITLE
Replace '卐' in `credits.mako` with actual credits

### DIFF
--- a/doc/pdoc_template/credits.mako
+++ b/doc/pdoc_template/credits.mako
@@ -1,1 +1,1 @@
-<p><span style="color:#ddd">&#21328;</span></p>
+<p><span style="color:#ddd"><a href="https://github.com/kernc">@kernc</a> and <a href="https://github.com/pdoc3/pdoc/graphs/contributors">others</a></span></p>


### PR DESCRIPTION
Regardless of the intent and the explanations that @kernc provided in #152 and #310, the unfortunate reality (in much of the world) is that swastikas today are much more widely recognized as/associated with Nazism than with Buddhism or anything benign. Note the following line from [Wikipedia](https://en.wikipedia.org/wiki/Swastika):

> in the West it continues to be strongly associated with [Nazism](https://en.wikipedia.org/wiki/Nazism), [antisemitism](https://en.wikipedia.org/wiki/Antisemitism), [white supremacism](https://en.wikipedia.org/wiki/White_supremacy), or simply [evil](https://en.wikipedia.org/wiki/Evil).

Given the lack of context/explanation regarding its presence on the website, it comes across at *best* as being in poor taste and at worst as a covert endorsement of Nazi ideology. As far as I can tell, there is no good reason for it to be there, so I think it should be removed. This PR replaces it with content that utilizes the `credits.mako` file/template as intended.