### PR TITLE
Simple implementation of appending markdown extensions

### DIFF
--- a/pdoc/html_helpers.py
+++ b/pdoc/html_helpers.py
@@ -409,8 +409,10 @@ class _MathPattern(InlineProcessor):
 
 def to_html(text: str, *,
             docformat: str = None,
-            module: pdoc.Module = None, link: Callable[..., str] = None,
-            latex_math: bool = False):
+            module: pdoc.Module = None,
+            link: Callable[..., str] = None,
+            latex_math: bool = False,
+            md_extensions: dict = None):
     """
     Returns HTML of `text` interpreted as `docformat`. `__docformat__` is respected
     if present, otherwise Numpydoc and Google-style docstrings are assumed,
@@ -427,6 +429,10 @@ def to_html(text: str, *,
         _md.inlinePatterns.register(_MathPattern(_MathPattern.PATTERN),
                                     _MathPattern.NAME,
                                     _MathPattern.PRIORITY)
+
+    # Optionally register additional markdown extensions
+    if md_extensions is not None:
+        _md.registerExtensions(**md_extensions)
 
     md = to_markdown(text, docformat=docformat, module=module, link=link)
     return _md.reset().convert(md)

--- a/pdoc/templates/config.mako
+++ b/pdoc/templates/config.mako
@@ -61,4 +61,7 @@
     # Note: in Python docstrings, either all backslashes need to be escaped (\\)
     # or you need to use raw r-strings.
     latex_math = False
+
+    # Register additional markdown extensions. See: https://python-markdown.github.io/extensions/admonition/
+    md_extensions = {'extensions': [], 'configs': {}}
 %>

--- a/pdoc/templates/html.mako
+++ b/pdoc/templates/html.mako
@@ -15,7 +15,7 @@
 
 
   def to_html(text):
-    return _to_html(text, docformat=docformat, module=module, link=link, latex_math=latex_math)
+    return _to_html(text, docformat=docformat, module=module, link=link, latex_math=latex_math, md_extensions=md_extensions)
 
 
   def get_annotation(bound_method, sep=':'):


### PR DESCRIPTION
A somewhat ugly implementation of the option to append markdown extensions, as suggested in #158 by @MPvHarmelen. Limitations mentioned in the comments of that issue apply.