### PR TITLE
feat: separate class and static methods in html.mako

### DIFF
--- a/pdoc/__init__.py
+++ b/pdoc/__init__.py
@@ -1186,17 +1186,32 @@ class Class(Doc):
         represent this class' methods.
         """
         return self._filter_doc_objs(
-            Function, include_inherited, lambda dobj: dobj.is_method,
+            Function, include_inherited, lambda dobj: dobj.is_instance_method,
             sort)
 
-    def functions(self, include_inherited=True, sort=True) -> List['Function']:
+    def static_methods(self, include_inherited=True, sort=True) -> List['Function']:
         """
         Returns an optionally-sorted list of `pdoc.Function` objects that
-        represent this class' static functions.
+        represent this class' static methods.
         """
         return self._filter_doc_objs(
-            Function, include_inherited, lambda dobj: not dobj.is_method,
-            sort)
+            Function,
+            include_inherited,
+            lambda dobj: Class._method_type(dobj.cls.obj, dobj.name) == staticmethod,
+            sort
+        )
+
+    def class_methods(self, include_inherited=True, sort=True) -> List['Function']:
+        """
+        Returns an optionally-sorted list of `pdoc.Function` objects that
+        represent this class' class methods.
+        """
+        return self._filter_doc_objs(
+            Function,
+            include_inherited,
+            lambda dobj: Class._method_type(dobj.cls.obj, dobj.name) == classmethod,
+            sort
+        )
 
     def inherited_members(self) -> List[Tuple['Class', List[Doc]]]:
         """
@@ -1338,7 +1353,7 @@ class Function(Doc):
         """
 
     @property
-    def is_method(self) -> bool:
+    def is_instance_method(self) -> bool:
         """
         Whether this function is a normal bound method.
 
@@ -1349,9 +1364,9 @@ class Function(Doc):
 
     @property
     def method(self):
-        warn('`Function.method` is deprecated. Use: `Function.is_method`', DeprecationWarning,
+        warn('`Function.method` is deprecated. Use: `Function.is_instance_method`', DeprecationWarning,
              stacklevel=2)
-        return self.is_method
+        return self.is_instance_method
 
     __pdoc__['Function.method'] = False
 

--- a/pdoc/templates/html.mako
+++ b/pdoc/templates/html.mako
@@ -178,7 +178,8 @@
     % for c in classes:
       <%
       class_vars = c.class_variables(show_inherited_members, sort=sort_identifiers)
-      smethods = c.functions(show_inherited_members, sort=sort_identifiers)
+      smethods = c.static_methods(show_inherited_members, sort=sort_identifiers)
+      cmethods = c.class_methods(show_inherited_members, sort=sort_identifiers)
       inst_vars = c.instance_variables(show_inherited_members, sort=sort_identifiers)
       methods = c.methods(show_inherited_members, sort=sort_identifiers)
       mro = c.mro()
@@ -225,6 +226,14 @@
           <h3>Static methods</h3>
           <dl>
           % for f in smethods:
+              ${show_func(f)}
+          % endfor
+          </dl>
+      % endif
+      % if cmethods:
+          <h3>Class methods</h3>
+          <dl>
+          % for f in cmethods:
               ${show_func(f)}
           % endfor
           </dl>
@@ -339,7 +348,11 @@
         <li>
         <h4><code>${link(c)}</code></h4>
         <%
-            members = c.functions(sort=sort_identifiers) + c.methods(sort=sort_identifiers)
+            members = (
+              c.static_methods(sort=sort_identifiers) 
+              + c.class_methods(sort=sort_identifiers)
+              + c.methods(sort=sort_identifiers)
+            )
             if list_class_variables_in_index:
                 members += (c.instance_variables(sort=sort_identifiers) +
                             c.class_variables(sort=sort_identifiers))

--- a/pdoc/templates/pdf.mako
+++ b/pdoc/templates/pdf.mako
@@ -128,7 +128,7 @@ ${classdef(cls)}
 ${cls.docstring | to_md, subh}
 <%
     class_vars = cls.class_variables(show_inherited_members, sort=sort_identifiers)
-    static_methods = cls.functions(show_inherited_members, sort=sort_identifiers)
+    static_methods = cls.static_methods(show_inherited_members, sort=sort_identifiers)
     inst_vars = cls.instance_variables(show_inherited_members, sort=sort_identifiers)
     methods = cls.methods(show_inherited_members, sort=sort_identifiers)
     mro = cls.mro()

--- a/pdoc/templates/text.mako
+++ b/pdoc/templates/text.mako
@@ -36,7 +36,7 @@ ${var.docstring | deflist}
 ${cls.docstring | deflist}
 <%
   class_vars = cls.class_variables(show_inherited_members, sort=sort_identifiers)
-  static_methods = cls.functions(show_inherited_members, sort=sort_identifiers)
+  static_methods = cls.static_methods(show_inherited_members, sort=sort_identifiers)
   inst_vars = cls.instance_variables(show_inherited_members, sort=sort_identifiers)
   methods = cls.methods(show_inherited_members, sort=sort_identifiers)
   mro = cls.mro()


### PR DESCRIPTION
Fixes #126 

I'm afraid I don't know much about Mako, so I didn't add class method sections PDF or text.

Future discussion: IMO, the ordering of method sections should go from most-specific to least-specific:

- Instance methods
- Class methods
- Static methods

There is one failing test on my local but it seems unrelated to this change, please LMK!

Cheers,
JP