### PR TITLE
Feature/better enums

### DIFF
--- a/pdoc/__init__.py
+++ b/pdoc/__init__.py
@@ -963,7 +963,7 @@ class Module(Doc):
         optionally sorted alphabetically, as a list of `pdoc.Class`.
         """
         enums = list(filter(lambda v: type(v) is EnumClass, self.doc.values()))
-        return sorted(enums, key=lambda x: x.value) if sort is True else enums
+        return sorted(enums, key=lambda x: x.obj.value) if sort is True else enums
 
     def functions(self, sort=True) -> List['Function']:
         """

--- a/pdoc/__init__.py
+++ b/pdoc/__init__.py
@@ -421,14 +421,14 @@ def _is_descriptor(obj):
             inspect.ismemberdescriptor(obj))
 
 
-def _filter_type(type: Type[T],
+def _filter_type(instance_type: Type[T],
                  values: Union[Iterable['Doc'], Mapping[str, 'Doc']]) -> List[T]:
     """
-    Return a list of values from `values` of type `type`.
+    Return a list of values from `values` of type `instance_type`.
     """
     if isinstance(values, dict):
         values = values.values()
-    return [i for i in values if isinstance(i, type)]
+    return [i for i in values if type(i) is instance_type]
 
 
 def _toposort(graph: Mapping[T, Set[T]]) -> Generator[T, None, None]:

--- a/pdoc/__init__.py
+++ b/pdoc/__init__.py
@@ -1085,7 +1085,7 @@ class Class(Doc):
                         var_docstrings.get(name) or
                         (inspect.isclass(obj) or _is_descriptor(obj)) and inspect.getdoc(obj)),
                     cls=self,
-                    obj=obj,
+                    obj=getattr(obj, 'fget', getattr(obj, '__get__', None)) or obj,
                     instance_var=(_is_descriptor(obj) or
                                   name in getattr(self.obj, '__slots__', ())))
 

--- a/pdoc/__init__.py
+++ b/pdoc/__init__.py
@@ -963,7 +963,7 @@ class Module(Doc):
         optionally sorted alphabetically, as a list of `pdoc.Class`.
         """
         enums = list(filter(lambda v: type(v) is EnumClass, self.doc.values()))
-        return sorted(enums) if sort is True else enums
+        return sorted(enums, key=lambda x: x.value) if sort is True else enums
 
     def functions(self, sort=True) -> List['Function']:
         """
@@ -1085,7 +1085,7 @@ class Class(Doc):
                         var_docstrings.get(name) or
                         (inspect.isclass(obj) or _is_descriptor(obj)) and inspect.getdoc(obj)),
                     cls=self,
-                    obj=obj,
+                    obj=getattr(obj, 'fget', getattr(obj, '__get__', None)) or obj,
                     instance_var=(_is_descriptor(obj) or
                                   name in getattr(self.obj, '__slots__', ())))
 

--- a/pdoc/__init__.py
+++ b/pdoc/__init__.py
@@ -1085,7 +1085,7 @@ class Class(Doc):
                         var_docstrings.get(name) or
                         (inspect.isclass(obj) or _is_descriptor(obj)) and inspect.getdoc(obj)),
                     cls=self,
-                    obj=getattr(obj, 'fget', getattr(obj, '__get__', None)),
+                    obj=obj,
                     instance_var=(_is_descriptor(obj) or
                                   name in getattr(self.obj, '__slots__', ())))
 

--- a/pdoc/__init__.py
+++ b/pdoc/__init__.py
@@ -957,13 +957,13 @@ class Module(Doc):
         """
         return self._filter_doc_objs(Class, sort)
     
-    def enums(self, sort=True) -> List['EnumClass']:
+    def enums(self, sort=False) -> List['EnumClass']:
         """
         Returns all documented module-level enums in the module,
         optionally sorted alphabetically, as a list of `pdoc.Class`.
         """
         enums = list(filter(lambda v: type(v) is EnumClass, self.doc.values()))
-        return sorted(enums, key=lambda x: x.obj.value) if sort is True else enums
+        return sorted(enums) if sort is True else enums
 
     def functions(self, sort=True) -> List['Function']:
         """

--- a/pdoc/__init__.py
+++ b/pdoc/__init__.py
@@ -962,7 +962,7 @@ class Module(Doc):
         Returns all documented module-level enums in the module,
         optionally sorted alphabetically, as a list of `pdoc.Class`.
         """
-        enums = list(filter(lambda item: type(item[1]) is EnumClass, self.doc.items()))
+        enums = list(filter(lambda v: type(v) is EnumClass, self.doc.values()))
         return sorted(enums) if sort is True else enums
 
     def functions(self, sort=True) -> List['Function']:

--- a/pdoc/__init__.py
+++ b/pdoc/__init__.py
@@ -962,7 +962,7 @@ class Module(Doc):
         Returns all documented module-level enums in the module,
         optionally sorted alphabetically, as a list of `pdoc.Class`.
         """
-        enums = list(filter(lambda _, v: type(v) is EnumClass, self.doc.items()))
+        enums = list(filter(lambda item: type(item[1]) is EnumClass, self.doc.items()))
         return sorted(enums) if sort is True else enums
 
     def functions(self, sort=True) -> List['Function']:

--- a/pdoc/__init__.py
+++ b/pdoc/__init__.py
@@ -1085,7 +1085,7 @@ class Class(Doc):
                         var_docstrings.get(name) or
                         (inspect.isclass(obj) or _is_descriptor(obj)) and inspect.getdoc(obj)),
                     cls=self,
-                    obj=getattr(obj, 'fget', getattr(obj, '__get__', None)) or obj,
+                    obj=obj,
                     instance_var=(_is_descriptor(obj) or
                                   name in getattr(self.obj, '__slots__', ())))
 

--- a/pdoc/__init__.py
+++ b/pdoc/__init__.py
@@ -957,7 +957,7 @@ class Module(Doc):
         """
         return self._filter_doc_objs(Class, sort)
     
-    def enums(self, sort=False) -> List['EnumClass']:
+    def enums(self, sort=True) -> List['EnumClass']:
         """
         Returns all documented module-level enums in the module,
         optionally sorted alphabetically, as a list of `pdoc.Class`.

--- a/pdoc/__init__.py
+++ b/pdoc/__init__.py
@@ -957,12 +957,13 @@ class Module(Doc):
         """
         return self._filter_doc_objs(Class, sort)
     
-    def enums(self) -> List['EnumClass']:
+    def enums(self, sort=True) -> List['EnumClass']:
         """
         Returns all documented module-level enums in the module,
         optionally sorted alphabetically, as a list of `pdoc.Class`.
         """
-        return list(filter(lambda _, v: type(v) is EnumClass, self.doc.items()))
+        enums = list(filter(lambda _, v: type(v) is EnumClass, self.doc.items()))
+        return sorted(enums) if sort is True else enums
 
     def functions(self, sort=True) -> List['Function']:
         """

--- a/pdoc/templates/html.mako
+++ b/pdoc/templates/html.mako
@@ -99,7 +99,7 @@
   <%
   variables = module.variables(sort=sort_identifiers)
   classes = module.classes(sort=sort_identifiers)
-  enums = module.enums(sort=False)
+  enums = module.enums(sort=sort_identifiers)
   functions = module.functions(sort=sort_identifiers)
   submodules = module.submodules()
   %>

--- a/pdoc/templates/html.mako
+++ b/pdoc/templates/html.mako
@@ -167,7 +167,7 @@
     <dl>
     % for e in enums:
       <%
-      definitions = c.class_variables(show_inherited_members, sort=sort_identifiers)
+      definitions = e.class_variables(show_inherited_members, sort=sort_identifiers)
       %>
       % if definitions:
           <dl>

--- a/pdoc/templates/html.mako
+++ b/pdoc/templates/html.mako
@@ -99,7 +99,7 @@
   <%
   variables = module.variables(sort=sort_identifiers)
   classes = module.classes(sort=sort_identifiers)
-  enums = module.enums(sort=sort_identifiers)
+  enums = module.enums(sort=False)
   functions = module.functions(sort=sort_identifiers)
   submodules = module.submodules()
   %>

--- a/pdoc/templates/html.mako
+++ b/pdoc/templates/html.mako
@@ -99,6 +99,7 @@
   <%
   variables = module.variables(sort=sort_identifiers)
   classes = module.classes(sort=sort_identifiers)
+  enums = module.enums(sort=sort_identifiers)
   functions = module.functions(sort=sort_identifiers)
   submodules = module.submodules()
   %>
@@ -155,6 +156,28 @@
       <% return_type = get_annotation(v.type_annotation) %>
       <dt id="${v.refname}"><code class="name">var ${ident(v.name)}${return_type}</code></dt>
       <dd>${show_desc(v)}</dd>
+    % endfor
+    </dl>
+    % endif
+  </section>
+
+  <section>
+    % if enums:
+    <h2 class="section-title" id="header-functions">Enums</h2>
+    <dl>
+    % for e in enums:
+      <%
+      definitions = c.class_variables(show_inherited_members, sort=sort_identifiers)
+      %>
+      % if definitions:
+          <dl>
+          % for v in class_vars:
+              <% return_type = get_annotation(v.type_annotation) %>
+              <dt id="${v.refname}"><code class="name">${ident(v.name)}${return_type}</code></dt>
+              <dd>${show_desc(v)}</dd>
+          % endfor
+          </dl>
+      % endif
     % endfor
     </dl>
     % endif

--- a/pdoc/templates/html.mako
+++ b/pdoc/templates/html.mako
@@ -169,15 +169,22 @@
       <%
       definitions = e.class_variables(show_inherited_members, sort=sort_identifiers)
       %>
+
+      <dt id="${e.refname}"><code class="flex name class">
+          <span>enum ${ident(e.name)}</span>
+      </code></dt>
+
+      <dd>${show_desc(e)}
+
       % if definitions:
           <dl>
-          % for v in class_vars:
-              <% return_type = get_annotation(v.type_annotation) %>
-              <dt id="${v.refname}"><code class="name">${ident(v.name)}${return_type}</code></dt>
+          % for v in definitions:
+              <dt id="${v.refname}"><code class="name">${ident(v.name)} = ${v.obj.value}</code></dt>
               <dd>${show_desc(v)}</dd>
           % endfor
           </dl>
       % endif
+      </dd>
     % endfor
     </dl>
     % endif

--- a/pdoc/templates/html.mako
+++ b/pdoc/templates/html.mako
@@ -310,6 +310,7 @@
   <%
   variables = module.variables(sort=sort_identifiers)
   classes = module.classes(sort=sort_identifiers)
+  enums = module.enums(sort=sort_identifiers)
   functions = module.functions(sort=sort_identifiers)
   submodules = module.submodules()
   supermodule = module.supermodule
@@ -359,6 +360,18 @@
     % if functions:
     <li><h3><a href="#header-functions">Functions</a></h3>
       ${show_column_list(functions)}
+    </li>
+    % endif
+
+    % if enums:
+    <li><h3><a href="#header-classes">Enums</a></h3>
+      <ul>
+      % for e in enums:
+        <li>
+        <h4><code>${link(e)}</code></h4>
+        </li>
+      % endfor
+      </ul>
     </li>
     % endif
 

--- a/pdoc/templates/html.mako
+++ b/pdoc/templates/html.mako
@@ -167,7 +167,7 @@
     <dl>
     % for e in enums:
       <%
-      definitions = e.class_variables(show_inherited_members, sort=sort_identifiers)
+      definitions = e.class_variables(show_inherited_members, sort=False)
       %>
 
       <dt id="${e.refname}"><code class="flex name class">


### PR DESCRIPTION
Generally, `Enums` in python are used a bit differently than classes and IMO should be treated distinctly.  Primarily, the "variables" should display what the enumeration corresponds to and they should not be sorted by default.

Here's a screenshot of how this PR formats a library I am working on:

![image](https://github.com/pdoc3/pdoc/assets/34154542/0875eea4-d73a-4f72-9d1d-cc836ee36c0c)


This PR implements simple parsing for Enums.  Initially, I subclassed `Class`.  It ended up not really being necessary within the scope of this PR, but nevertheless could provide a nice place to extend functionality if necessary.