### PR TITLE
ENH: Handle union type expressions for Google style docstrings

### DIFF
--- a/pdoc/html_helpers.py
+++ b/pdoc/html_helpers.py
@@ -248,14 +248,14 @@ class _ToMarkdown:
             section = section.title()
             if section in ('Args', 'Attributes'):
                 body = re.compile(
-                    r'^([\w*]+)(?: \(([\w.,=\[\] -]+)\))?: '
+                    r'^([\w*]+)(?: \(([\w.,=|\[\] -]+)\))?: '
                     r'((?:.*)(?:\n(?: {2,}.*|$))*)', re.MULTILINE).sub(
                     lambda m: _ToMarkdown._deflist(*_ToMarkdown._fix_indent(*m.groups())),
                     inspect.cleandoc(f'\n{body}')
                 )
             elif section in ('Returns', 'Yields', 'Raises', 'Warns'):
                 body = re.compile(
-                    r'^()([\w.,\[\] ]+): '
+                    r'^()([\w.,|\[\] ]+): '
                     r'((?:.*)(?:\n(?: {2,}.*|$))*)', re.MULTILINE).sub(
                     lambda m: _ToMarkdown._deflist(*_ToMarkdown._fix_indent(*m.groups())),
                     inspect.cleandoc(f'\n{body}')

--- a/pdoc/test/__init__.py
+++ b/pdoc/test/__init__.py
@@ -1457,6 +1457,8 @@ Nomatch:</p>
 <dd>Description of arg1</dd>
 <dt><strong><code>arg2</code></strong> :&ensp;<code>str</code> or <code>int</code></dt>
 <dd>Description of arg2</dd>
+<dt><strong><code>arg3</code></strong> :&ensp;<code>str | None</code></dt>
+<dd>Description of arg3</dd>
 <dt><strong><code>test_sequence</code></strong></dt>
 <dd>
 <p>2-dim numpy array of real numbers, size: N * D
@@ -1482,6 +1484,11 @@ which is the answer of everything.</p>
 <h2 id="returns_2">Returns</h2>
 <dl>
 <dt><code>Dict[int, <a>pdoc.Doc</a>]</code></dt>
+<dd>Description.</dd>
+</dl>
+<h2 id="returns_3">Returns</h2>
+<dl>
+<dt><code>int | str</code></dt>
 <dd>Description.</dd>
 </dl>
 <h2 id="raises">Raises</h2>

--- a/pdoc/test/example_pkg/__init__.py
+++ b/pdoc/test/example_pkg/__init__.py
@@ -223,6 +223,7 @@ class Docformats:
         Args:
           arg1 (int): Description of arg1
           arg2 (str or int): Description of arg2
+          arg3 (str | None): Description of arg3
           test_sequence: 2-dim numpy array of real numbers, size: N * D
             - the test observation sequence.
 
@@ -243,6 +244,9 @@ class Docformats:
 
         Returns:
             Dict[int, pdoc.Doc]: Description.
+
+        Returns:
+            int | str: Description.
 
         Raises:
             AttributeError: The ``Raises`` section is a list of all exceptions


### PR DESCRIPTION
This PR addresses [issue #441](https://github.com/pdoc3/pdoc/issues/441) by tweaking the regex expression used to parse Google-style docstrings to handle union-type expressions correctly. 

I also updated the test for this docstring format to ensure the fix works as expected and prevent regressions in the future.

