### PR TITLE
BUG: crash: collections.abc.Callable does not allow tuple in Python 3.10

### DIFF
--- a/pdoc/__init__.py
+++ b/pdoc/__init__.py
@@ -1354,7 +1354,7 @@ def _formatannotation(annot):
                 try:
                     a = a.__origin__[args]
                 except TypeError:
-                    # XXX: Python 3.10-only: Need to convert to list since _CallableGenericAlias.__new__
+                    # XXX: Python 3.10-only: Convert to list since _CallableGenericAlias.__new__
                     #                        currently cannot have tuples as arguments.
                     args_in = list(args[:-1])
                     arg_out = args[-1]

--- a/pdoc/__init__.py
+++ b/pdoc/__init__.py
@@ -1354,8 +1354,12 @@ def _formatannotation(annot):
                 try:
                     a = a.__origin__[args]
                 except TypeError:
+                    # XXX: Python 3.10-only: Need to convert to list since _CallableGenericAlias.__new__
+                    #                        currently cannot have tuples as arguments.
+                    args_in = list(args[:-1])
+                    arg_out = args[-1]
                     # collections.abc.Callable takes "([in], out)"
-                    a = a.__origin__[(list(args[:-1]), args[-1])]
+                    a = a.__origin__[(args_in, arg_out)]
         # Recurse into lists
         if isinstance(a, (list, tuple)):
             return type(a)(map(maybe_replace_reprs, a))

--- a/pdoc/__init__.py
+++ b/pdoc/__init__.py
@@ -1355,7 +1355,7 @@ def _formatannotation(annot):
                     a = a.__origin__[args]
                 except TypeError:
                     # collections.abc.Callable takes "([in], out)"
-                    a = a.__origin__[(args[:-1], args[-1])]
+                    a = a.__origin__[(list(args[:-1]), args[-1])]
         # Recurse into lists
         if isinstance(a, (list, tuple)):
             return type(a)(map(maybe_replace_reprs, a))


### PR DESCRIPTION
This PR is about the following line:
https://github.com/pdoc3/pdoc/blob/65342aecd782326b4c98492bbf9102c3534a735a/pdoc/__init__.py#L1358

In Python 3.10, `_CallableGenericAlias.__new__` does an explicit check for `list` and not `(tuple | list)`, so the current code crashes in the except clause when the args tuple is sliced into a new tuple.

Here's the type check in Python 3.10:
https://github.com/python/cpython/blob/8773554b717cfb08b4bd11a927813f4ed74762c7/Lib/_collections_abc.py#L433

The same line in Python 3.11:
https://github.com/python/cpython/blob/f0895aa9c1d40d0add673cc51bd143556e22100a/Lib/_collections_abc.py#L433

I suggest we explicitly convert the first argument to `__origin__` to a list for backwards compatibility. Unittests failed before, now they pass.