### PR TITLE
BUG: Fix unrecognized Setext headers with Python-Markdown 3.10.3

### DIFF
--- a/pdoc/html_helpers.py
+++ b/pdoc/html_helpers.py
@@ -262,7 +262,7 @@ class _ToMarkdown:
                 )
             # Convert into markdown sections. End underlines with '='
             # to avoid matching and re-processing as Numpy sections.
-            return f'\n{section}\n-----=\n{body}'
+            return f'\n## {section}\n\n{body}'
 
         text = re.compile(r'^([A-Z]\w+):$\n'
                           r'((?:\n?(?: {2,}.*|$))+)', re.MULTILINE).sub(googledoc_sections, text)


### PR DESCRIPTION
Notably, converting googledoc `Returns:` to markdown:

    Returns
    -----=

is no longer valid.
We used the `[-=]` mixture to avoid reinterpreting as Numpydoc, but this approach is invalid and henceforth unsupported.

* https://github.com/Python-Markdown/markdown/issues/1604
* https://github.com/Python-Markdown/markdown/commit/ddead47873e7918829e1d8b0eaee6ab725793cc9