### PR TITLE
BUG: Fix return_annotation() skipping fallback for C-builtins

### DIFF
--- a/pdoc/__init__.py
+++ b/pdoc/__init__.py
@@ -1487,12 +1487,9 @@ class Function(Doc):
                 annot = method()
             except Exception:
                 continue
-            else:
+
+            if annot is not inspect.Parameter.empty:
                 break
-        else:
-            # Don't warn on variables. The annotation just isn't available.
-            if not isinstance(self, Variable):
-                warn(f"Error handling return annotation for {self!r}", stacklevel=3)
 
         if annot is inspect.Parameter.empty or not annot:
             return ''

--- a/pdoc/test/__init__.py
+++ b/pdoc/test/__init__.py
@@ -1004,6 +1004,13 @@ class ApiTest(unittest.TestCase):
         self.assertEqual(pdoc.Function('get_sample', mod, get_sample).return_annotation(),
                          'Tuple[int,\xa0float]')
 
+        # builtin-like callable, where inspect.signature() succeeds, but parameters/return
+        # annotation are empty, so the signature in the doc string will be used
+        class get_sample_2():
+            """ get_sample_2(self: int, pos: int) -> Tuple[int, float] """
+        self.assertEqual(pdoc.Function('get_sample_2', mod, get_sample_2).return_annotation(),
+                         'Tuple[int,\xa0float]')
+
     @unittest.skipIf(sys.version_info < (3, 8), "positional-only arguments unsupported in < py3.8")
     def test_test_Function_params_python38_specific(self):
         mod = DUMMY_PDOC_MODULE


### PR DESCRIPTION
Continue fallback when `inspect.signature().return_annotation` returns `Parameter.empty`, allowing return annotations to be parsed from C-buildins docstrings.

Remove misleading `UserWarning: Error handling return annotation for ...`.
Empty return annotations are totally normal and expected for many function
signatures.

This fixes #474